### PR TITLE
Agregar opciones de filtrado al registro de empleados

### DIFF
--- a/src/main/java/mx/com/ferbo/controller/RegistroEmpleadosBean.java
+++ b/src/main/java/mx/com/ferbo/controller/RegistroEmpleadosBean.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 import javax.faces.application.FacesMessage;
@@ -74,8 +75,7 @@ import mx.com.ferbo.util.SGPException;
 @Named(value = "registroEmpleadosBean")
 @ViewScoped
 public class RegistroEmpleadosBean implements Serializable {
-    
-    
+
     private static final long serialVersionUID = 1L;
     private static final Logger log = LogManager.getLogger(RegistroEmpleadosBean.class);
 
@@ -121,6 +121,11 @@ public class RegistroEmpleadosBean implements Serializable {
     private List<CatAsentamiento> lstAsentamientos;
     private List<DetDomicilioEmpleado> lstDomicilios;
 
+    private CatPlanta plantaselected;
+    private CatEmpresa empresaselected;
+    private boolean activo;
+    private boolean inactivo;
+    
     private DetEmpleado empleadoSelected;
     private DetBiometrico detBiometrico;
     private DetEmpleadoFoto empleadoFoto;
@@ -130,16 +135,16 @@ public class RegistroEmpleadosBean implements Serializable {
     private DetPrestamo prestamo;
     private CatAsentamiento asentamientoSelected;
     private DetDomicilioEmpleado domicilioEmpleadoSelected;
-    
+
     private String curp;
     private String rfc;
     private String nss;
     private String codigoPostal;
-    
+
     public RegistroEmpleadosBean() {
-    	empleadoFotoDAO = new EmpleadoFotoDAO(DetEmpleadoFoto.class);
-    	prestamoDAO = new PrestamoDAO();
-    	percepcionEmpleadoDAO = new PercepcionEmpleadoDAO();
+        empleadoFotoDAO = new EmpleadoFotoDAO(DetEmpleadoFoto.class);
+        prestamoDAO = new PrestamoDAO();
+        percepcionEmpleadoDAO = new PercepcionEmpleadoDAO();
         empresaDAO = new EmpresaDAO(CatEmpresa.class);
         perfilDAO = new PerfilDAO(CatPerfil.class);
         plantaDAO = new PlantaDAO(CatPlanta.class);
@@ -158,7 +163,7 @@ public class RegistroEmpleadosBean implements Serializable {
         tipoPrestamoDAO = new TipoPrestamoDAO();
         domicilioEmpleadoDAO = new DomicilioEmpleadoDAO();
         asentamientoDAO = new AsentamientoDAO();
-        
+
         empleadoSelected = new DetEmpleado();
         lstEmpleados = new ArrayList<>();
         lstEmpleadosSelected = new ArrayList<>();
@@ -166,6 +171,8 @@ public class RegistroEmpleadosBean implements Serializable {
 
     @PostConstruct
     public void init() {
+        this.activo = false;
+        this.inactivo = false;
         try {
             lstCatEmpresa = empresaDAO.buscarActivo();
             lstCatPerfil = perfilDAO.buscarActivo();
@@ -180,7 +187,7 @@ public class RegistroEmpleadosBean implements Serializable {
             periodicidadesPago = periodicidadDAO.buscarActivos(new Date());
             tiposPercepcion = tipoPercepcionDAO.buscarTodos();
             tiposPrestamo = tipoPrestamoDAO.buscarTodos();
-            
+
             consultaEmpleados();
             prestamo = new DetPrestamo();
             domicilioEmpleadoSelected = new DetDomicilioEmpleado();
@@ -188,28 +195,26 @@ public class RegistroEmpleadosBean implements Serializable {
             log.warn("EX-0008: " + ex.getMessage() + ". Error al cargar init()");
         }
     }
-    
+
     /*
      * Método para consultar los domicilios de los empleados
      */
-    private void consultaAsentamientos()
-    {
+    private void consultaAsentamientos() {
         this.lstAsentamientos = asentamientoDAO.buscarTodos();
     }
-    
+
     /*
      * Método para consultar los domicilios de los empleados
      */
-    private void consultaDomicilios()
-    {
+    private void consultaDomicilios() {
         this.lstDomicilios = domicilioEmpleadoDAO.buscarTodos();
     }
-    
+
     /*
      * Método para consultar a los empleados
      */
     private void consultaEmpleados() {
-    	this.lstEmpleados = empleadoDAO.buscarTodos(false);
+        this.lstEmpleados = empleadoDAO.buscarTodos(false);
     }
 
     /*
@@ -235,327 +240,326 @@ public class RegistroEmpleadosBean implements Serializable {
      */
     public void agregarEmpleado() {
         this.empleadoSelected = new DetEmpleado();
-        this.empleadoSelected.setActivo((short)1);
+        this.empleadoSelected.setActivo((short) 1);
         this.datoEmpresa = new InfDatoEmpresa();
         this.empleadoSelected.setDatoEmpresa(this.datoEmpresa);
         this.domicilioEmpleadoSelected = new DetDomicilioEmpleado();
         this.asentamientoSelected = this.inicializarAsentamiento();
     }
-    
-    public CatAsentamiento obtenerAsentamiento(DetDomicilioEmpleado domicilioEmpleado)
-    {
+
+    public CatAsentamiento obtenerAsentamiento(DetDomicilioEmpleado domicilioEmpleado) {
         CatAsentamiento asentamiento = null;
-        
-        if(domicilioEmpleado != null)
-        {
-            asentamiento = this.asentamientoDAO.buscarPorParametros(domicilioEmpleado.getAsentamiento(), 
-                domicilioEmpleado.getLocalidad(), 
-                domicilioEmpleado.getMunicipio(), 
-                domicilioEmpleado.getEstado(), 
-                domicilioEmpleado.getPais());
+
+        if (domicilioEmpleado != null) {
+            asentamiento = this.asentamientoDAO.buscarPorParametros(domicilioEmpleado.getAsentamiento(),
+                    domicilioEmpleado.getLocalidad(),
+                    domicilioEmpleado.getMunicipio(),
+                    domicilioEmpleado.getEstado(),
+                    domicilioEmpleado.getPais());
             log.trace("Asentamiento obtenido {}", asentamiento.toString());
-        }else
-        {
+        } else {
             log.info("No se encontro asentamiento del empleado {}", this.empleadoSelected.getIdEmpleado());
         }
-        
+
         return asentamiento;
     }
-    
-    public void agregarAsentamientoADomicilio(CatAsentamiento auxAsentamiento)
-    {
+
+    public void agregarAsentamientoADomicilio(CatAsentamiento auxAsentamiento) {
         log.debug("Agregando/Actualizando asentamiento en domicilio");
-        if(auxAsentamiento != null)
-        {
+        if (auxAsentamiento != null) {
             this.domicilioEmpleadoSelected.setAsentamiento(auxAsentamiento.getKey().getId());
             this.domicilioEmpleadoSelected.setLocalidad(auxAsentamiento.getKey().getLocalidad().getKey().getId());
             this.domicilioEmpleadoSelected.setMunicipio(auxAsentamiento.getKey().getLocalidad().getKey().getMunicipio().getKey().getId());
             this.domicilioEmpleadoSelected.setEstado(auxAsentamiento.getKey().getLocalidad().getKey().getMunicipio().getKey().getEstado().getKey().getId());
             this.domicilioEmpleadoSelected.setPais(auxAsentamiento.getKey().getLocalidad().getKey().getMunicipio().getKey().getEstado().getKey().getPais().getId());
         }
-        
+
     }
-    
-    public void editar() 
-    {
-        if(this.empleadoSelected.getIdEmpleado() != null)
-        {
+
+    public void editar() {
+        if (this.empleadoSelected.getIdEmpleado() != null) {
             limpiarVariables();
         }
-        
-    	List<DetPrestamo> prestamos = null;
-    	log.info("Cargando información del empleado: {}", this.empleadoSelected);
+
+        List<DetPrestamo> prestamos = null;
+        log.info("Cargando información del empleado: {}", this.empleadoSelected);
         InfDatoEmpresa datoEmpresa = this.empleadoSelected.getDatoEmpresa();
-    	this.empleadoFoto = empleadoFotoDAO.buscar(this.empleadoSelected.getNumEmpleado());
-    	
-    	if(datoEmpresa == null) {
-    		this.datoEmpresa = new InfDatoEmpresa();
-    		this.empleadoSelected.setDatoEmpresa(this.datoEmpresa);
-    	} else {
-    		this.datoEmpresa = datoEmpresa;
-    		this.rfc = this.datoEmpresa.getRfc();
-    		this.nss = this.datoEmpresa.getNss();
-    		this.curp = this.empleadoSelected.getCurp();
-    	}
-    	
-    	percepcionesEmpleado = percepcionEmpleadoDAO.buscarPorEmpleado(this.empleadoSelected.getIdEmpleado());
-    	prestamos = prestamoDAO.buscar(this.empleadoSelected.getIdEmpleado());
-    	this.empleadoSelected.setPrestamos(prestamos); 
-    	this.prestamo = new DetPrestamo();
-    	
-    	log.info("Empleado seleccionado: {}", this.empleadoSelected.getIdEmpleado());
-    	if(empleadoFoto != null)
-    		log.debug("Foto: {}", empleadoFoto.getFotografia());
-    	
+        this.empleadoFoto = empleadoFotoDAO.buscar(this.empleadoSelected.getNumEmpleado());
+
+        if (datoEmpresa == null) {
+            this.datoEmpresa = new InfDatoEmpresa();
+            this.empleadoSelected.setDatoEmpresa(this.datoEmpresa);
+        } else {
+            this.datoEmpresa = datoEmpresa;
+            this.rfc = this.datoEmpresa.getRfc();
+            this.nss = this.datoEmpresa.getNss();
+            this.curp = this.empleadoSelected.getCurp();
+        }
+
+        percepcionesEmpleado = percepcionEmpleadoDAO.buscarPorEmpleado(this.empleadoSelected.getIdEmpleado());
+        prestamos = prestamoDAO.buscar(this.empleadoSelected.getIdEmpleado());
+        this.empleadoSelected.setPrestamos(prestamos);
+        this.prestamo = new DetPrestamo();
+
+        log.info("Empleado seleccionado: {}", this.empleadoSelected.getIdEmpleado());
+        if (empleadoFoto != null) {
+            log.debug("Foto: {}", empleadoFoto.getFotografia());
+        }
+
         this.domicilioEmpleadoSelected = this.domicilioEmpleadoDAO.buscarPorId(this.empleadoSelected.getIdEmpleado());
-        
-        if(this.domicilioEmpleadoSelected != null)
-        {
+
+        if (this.domicilioEmpleadoSelected != null) {
             this.asentamientoSelected = this.obtenerAsentamiento(this.domicilioEmpleadoSelected);
             log.info("Cargando información del domicilio {} y del asentamiento {}", this.domicilioEmpleadoSelected.toString(), this.asentamientoSelected.toString());
-        }else
-        {
+        } else {
             this.domicilioEmpleadoSelected = new DetDomicilioEmpleado();
             this.asentamientoSelected = this.inicializarAsentamiento();
         }
-        
-    	this.detBiometrico = biometricoDAO.consultaBiometricoByIdEmpleado(this.empleadoSelected.getIdEmpleado());
-    	
-	log.info("Biometrico: {}", this.detBiometrico);
-        
-		this.nuevaPercepcionEmpleado();
-    	PrimeFaces.current().ajax().update("formRegistroEmpleado:messages", "formRegistroEmpleado:panelDialogFoto", "formRegistroEmpleado:panelDialogEmpleado");
+
+        this.detBiometrico = biometricoDAO.consultaBiometricoByIdEmpleado(this.empleadoSelected.getIdEmpleado());
+
+        log.info("Biometrico: {}", this.detBiometrico);
+
+        this.nuevaPercepcionEmpleado();
+        PrimeFaces.current().ajax().update("formRegistroEmpleado:messages", "formRegistroEmpleado:panelDialogFoto", "formRegistroEmpleado:panelDialogEmpleado");
     }
-    
+
     public void nuevaPercepcionEmpleado() {
-    	this.percepcionEmpleado = new DetPercepcionEmpleado();
-		this.percepcionEmpleado.setEmpleado(this.empleadoSelected);
-		this.percepcionEmpleado.setActivo(true);
+        this.percepcionEmpleado = new DetPercepcionEmpleado();
+        this.percepcionEmpleado.setEmpleado(this.empleadoSelected);
+        this.percepcionEmpleado.setActivo(true);
     }
-    
+
     public void agregarPercepcionEmpleado() {
-    	log.info("Agregando percepcion del empleado...");
-    	if(this.percepcionesEmpleado == null)
-    		this.percepcionesEmpleado = new ArrayList<>();
-    	
-    	this.percepcionEmpleado.setEmpleado(this.empleadoSelected);
-    	this.percepcionesEmpleado.add(percepcionEmpleado);
-    	this.nuevaPercepcionEmpleado();
+        log.info("Agregando percepcion del empleado...");
+        if (this.percepcionesEmpleado == null) {
+            this.percepcionesEmpleado = new ArrayList<>();
+        }
+
+        this.percepcionEmpleado.setEmpleado(this.empleadoSelected);
+        this.percepcionesEmpleado.add(percepcionEmpleado);
+        this.nuevaPercepcionEmpleado();
     }
-    
+
     public void eliminarPercepcionEmpleado() {
-    	FacesMessage message = null;
-		Severity severity = null;
-		String mensaje = null;
-		String titulo = "Percepción del empleado";
-		
-		try {
-			if(this.percepcionEmpleado == null)
-				throw new SGPException("Debe indicar una percepción");
-			
-			this.percepcionesEmpleado.remove(this.percepcionEmpleado);
-			this.percepcionEmpleado = new DetPercepcionEmpleado();
-			
-			mensaje = "Percepción eliminada correctamente.";
-    		severity = FacesMessage.SEVERITY_INFO;
-		} catch(SGPException ex) {
-    		mensaje = ex.getMessage();
-    		severity = FacesMessage.SEVERITY_WARN;
-    	} catch(Exception ex) {
-    		log.error("Problema para guardar información del empleado...", ex);
-    		mensaje = "Problema para guardar al empleado.";
-    		severity = FacesMessage.SEVERITY_ERROR;
-    	} finally {
-    		message = new FacesMessage(severity, titulo, mensaje);
-			FacesContext.getCurrentInstance().addMessage(null, message);
-	        PrimeFaces.current().ajax().update("formRegistroEmpleado:messages", "formRegistroEmpleado:panelDialogEmpleado:dt-percepcion-empleado");
-    	}
+        FacesMessage message = null;
+        Severity severity = null;
+        String mensaje = null;
+        String titulo = "Percepción del empleado";
+
+        try {
+            if (this.percepcionEmpleado == null) {
+                throw new SGPException("Debe indicar una percepción");
+            }
+
+            this.percepcionesEmpleado.remove(this.percepcionEmpleado);
+            this.percepcionEmpleado = new DetPercepcionEmpleado();
+
+            mensaje = "Percepción eliminada correctamente.";
+            severity = FacesMessage.SEVERITY_INFO;
+        } catch (SGPException ex) {
+            mensaje = ex.getMessage();
+            severity = FacesMessage.SEVERITY_WARN;
+        } catch (Exception ex) {
+            log.error("Problema para guardar información del empleado...", ex);
+            mensaje = "Problema para guardar al empleado.";
+            severity = FacesMessage.SEVERITY_ERROR;
+        } finally {
+            message = new FacesMessage(severity, titulo, mensaje);
+            FacesContext.getCurrentInstance().addMessage(null, message);
+            PrimeFaces.current().ajax().update("formRegistroEmpleado:messages", "formRegistroEmpleado:panelDialogEmpleado:dt-percepcion-empleado");
+        }
     }
-    
+
     public void agregarPrestamo() {
-    	FacesMessage message = null;
-		Severity severity = null;
-		String mensaje = null;
-		String titulo = "Préstamo";
-		
-		try {
-			if(this.prestamo == null)
-				throw new SGPException("Debe indicar un préstamo");
-			
-			if(this.prestamo.getTipoPrestamo() == null)
-				throw new SGPException("Debe indicar el tipo de préstamo");
-			
-			if(this.prestamo.getFechaInicio() == null)
-				throw new SGPException("Debe indicar la fecha de inicio del préstamo.");
-			
-			if(this.prestamo.getFechaFin() == null)
-				throw new SGPException("Debe indicar la fecha de fin del préstamo.");
-			
-			if(this.prestamo.getAcumulado() == null)
-				throw new SGPException("Debe indicar el acumulado del préstamo.");
-			
-			if(this.prestamo.getImporte() == null)
-				throw new SGPException("Debe indicar el importe del préstamo.");
-			
-			if(this.prestamo.getTotal() == null)
-				throw new SGPException("Debe indicar el total del préstamo.");
-			
-			if(this.prestamo.getPeriodicidadPago() == null)
-				throw new SGPException("Debe indicar la periodicidad de pago.");
-			
-			if(this.empleadoSelected.getPrestamos() == null)
-				this.empleadoSelected.setPrestamos(new ArrayList<>());
-			
-			prestamo.setEmpleado(this.empleadoSelected);
-			
-			this.empleadoSelected.getPrestamos().add(prestamo);
-			
-			prestamo = new DetPrestamo();
-			PrimeFaces.current().executeScript("PF('dgPrestamo').hide()");
-			
-			mensaje = "Préstamo agregado correctamente.";
-    		severity = FacesMessage.SEVERITY_INFO;
-		} catch(SGPException ex) {
-    		mensaje = ex.getMessage();
-    		severity = FacesMessage.SEVERITY_WARN;
-    	} catch(Exception ex) {
-    		log.error("Problema para guardar información del empleado...", ex);
-    		mensaje = "Problema para guardar al empleado.";
-    		severity = FacesMessage.SEVERITY_ERROR;
-    	} finally {
-    		message = new FacesMessage(severity, titulo, mensaje);
-			FacesContext.getCurrentInstance().addMessage(null, message);
-	        PrimeFaces.current().ajax().update("formRegistroEmpleado:messages", "formRegistroEmpleado:panelDialogEmpleado:dt-prestamos");
-    	}
+        FacesMessage message = null;
+        Severity severity = null;
+        String mensaje = null;
+        String titulo = "Préstamo";
+
+        try {
+            if (this.prestamo == null) {
+                throw new SGPException("Debe indicar un préstamo");
+            }
+
+            if (this.prestamo.getTipoPrestamo() == null) {
+                throw new SGPException("Debe indicar el tipo de préstamo");
+            }
+
+            if (this.prestamo.getFechaInicio() == null) {
+                throw new SGPException("Debe indicar la fecha de inicio del préstamo.");
+            }
+
+            if (this.prestamo.getFechaFin() == null) {
+                throw new SGPException("Debe indicar la fecha de fin del préstamo.");
+            }
+
+            if (this.prestamo.getAcumulado() == null) {
+                throw new SGPException("Debe indicar el acumulado del préstamo.");
+            }
+
+            if (this.prestamo.getImporte() == null) {
+                throw new SGPException("Debe indicar el importe del préstamo.");
+            }
+
+            if (this.prestamo.getTotal() == null) {
+                throw new SGPException("Debe indicar el total del préstamo.");
+            }
+
+            if (this.prestamo.getPeriodicidadPago() == null) {
+                throw new SGPException("Debe indicar la periodicidad de pago.");
+            }
+
+            if (this.empleadoSelected.getPrestamos() == null) {
+                this.empleadoSelected.setPrestamos(new ArrayList<>());
+            }
+
+            prestamo.setEmpleado(this.empleadoSelected);
+
+            this.empleadoSelected.getPrestamos().add(prestamo);
+
+            prestamo = new DetPrestamo();
+            PrimeFaces.current().executeScript("PF('dgPrestamo').hide()");
+
+            mensaje = "Préstamo agregado correctamente.";
+            severity = FacesMessage.SEVERITY_INFO;
+        } catch (SGPException ex) {
+            mensaje = ex.getMessage();
+            severity = FacesMessage.SEVERITY_WARN;
+        } catch (Exception ex) {
+            log.error("Problema para guardar información del empleado...", ex);
+            mensaje = "Problema para guardar al empleado.";
+            severity = FacesMessage.SEVERITY_ERROR;
+        } finally {
+            message = new FacesMessage(severity, titulo, mensaje);
+            FacesContext.getCurrentInstance().addMessage(null, message);
+            PrimeFaces.current().ajax().update("formRegistroEmpleado:messages", "formRegistroEmpleado:panelDialogEmpleado:dt-prestamos");
+        }
     }
-    
+
     public void eliminarPrestamo(DetPrestamo prestamo) {
-    	FacesMessage message = null;
-		Severity severity = null;
-		String mensaje = null;
-		String titulo = "Préstamo";
-		
-		try {
-			if(this.prestamo == null)
-				throw new SGPException("Debe indicar un préstamo");
-			
-			this.empleadoSelected.getPrestamos().remove(this.prestamo);
-			
-			prestamo = new DetPrestamo();
-			PrimeFaces.current().executeScript("PF('dgPrestamo').hide()");
-			
-			mensaje = "Préstamo eliminado correctamente.";
-    		severity = FacesMessage.SEVERITY_INFO;
-		} catch(SGPException ex) {
-    		mensaje = ex.getMessage();
-    		severity = FacesMessage.SEVERITY_WARN;
-    	} catch(Exception ex) {
-    		log.error("Problema para guardar información del empleado...", ex);
-    		mensaje = "Problema para guardar al empleado.";
-    		severity = FacesMessage.SEVERITY_ERROR;
-    	} finally {
-    		message = new FacesMessage(severity, titulo, mensaje);
-			FacesContext.getCurrentInstance().addMessage(null, message);
-	        PrimeFaces.current().ajax().update("formRegistroEmpleado:messages", "formRegistroEmpleado:panelDialogEmpleado:dt-prestamos");
-    	}
+        FacesMessage message = null;
+        Severity severity = null;
+        String mensaje = null;
+        String titulo = "Préstamo";
+
+        try {
+            if (this.prestamo == null) {
+                throw new SGPException("Debe indicar un préstamo");
+            }
+
+            this.empleadoSelected.getPrestamos().remove(this.prestamo);
+
+            prestamo = new DetPrestamo();
+            PrimeFaces.current().executeScript("PF('dgPrestamo').hide()");
+
+            mensaje = "Préstamo eliminado correctamente.";
+            severity = FacesMessage.SEVERITY_INFO;
+        } catch (SGPException ex) {
+            mensaje = ex.getMessage();
+            severity = FacesMessage.SEVERITY_WARN;
+        } catch (Exception ex) {
+            log.error("Problema para guardar información del empleado...", ex);
+            mensaje = "Problema para guardar al empleado.";
+            severity = FacesMessage.SEVERITY_ERROR;
+        } finally {
+            message = new FacesMessage(severity, titulo, mensaje);
+            FacesContext.getCurrentInstance().addMessage(null, message);
+            PrimeFaces.current().ajax().update("formRegistroEmpleado:messages", "formRegistroEmpleado:panelDialogEmpleado:dt-prestamos");
+        }
     }
-    
+
     /*
      * Método para guardar empleado
      */
     public synchronized void guardarEmpleado() {
-    	FacesMessage message = null;
+        FacesMessage message = null;
         Severity severity = null;
         String mensaje = null;
         String titulo = "Guardar empleado";
         CatParametro pNumeroEmpleado = null;
         String sNumeroEmpleado = null;
         int numeroEmpleado = -1;
-    	try {
-    		this.empleadoSelected.setPercepcionesEmpleado(this.percepcionesEmpleado);
-    		
-                if(this.domicilioEmpleadoSelected.getCalle() == null)
-                {
-                    log.error("No se capturo la calle");
-                    throw new SGPException("Debe indicar una calle");
+        try {
+            this.empleadoSelected.setPercepcionesEmpleado(this.percepcionesEmpleado);
+
+            if (this.domicilioEmpleadoSelected.getCalle() == null) {
+                log.error("No se capturo la calle");
+                throw new SGPException("Debe indicar una calle");
+            }
+
+            if (this.domicilioEmpleadoSelected.getNumeroExterior() == null) {
+                log.error("No se capturo el numero exterior");
+                throw new SGPException("Debe indicar un numero de calle exterior");
+            }
+
+            if (this.datoEmpresa.getFechaIngreso() == null) {
+                log.error("Falta fecha de ingreso en dato empresa");
+                throw new SGPException("Debe indicar la fecha de ingreso");
+            }
+
+            if (this.datoEmpresa.getFechaIngreso() == null) {
+                log.error("Falta fecha de ingreso");
+                throw new SGPException("Debe indicar una fecha de ingreso");
+            }
+
+            if (this.empleadoSelected.getIdEmpleado() == null) {
+                pNumeroEmpleado = this.parametroDAO.buscarPorClave("NBEMP");
+                sNumeroEmpleado = pNumeroEmpleado.getValor();
+                numeroEmpleado = Integer.parseInt(sNumeroEmpleado);
+                sNumeroEmpleado = String.format("%04d", ++numeroEmpleado);
+                transformarAMayusculas();
+                this.empleadoSelected.setNumEmpleado(sNumeroEmpleado);
+                this.empleadoSelected.setDatoEmpresa(this.datoEmpresa);
+                this.empleadoSelected.setFechaRegistro(new Date());
+                empleadoDAO.guardar(empleadoSelected);
+                this.domicilioEmpleadoSelected.setEmpleado(this.empleadoSelected);
+                this.domicilioEmpleadoDAO.guardar(domicilioEmpleadoSelected);
+                pNumeroEmpleado.setValor(sNumeroEmpleado);
+                this.parametroDAO.actualizar(pNumeroEmpleado);
+            } else {
+                empleadoDAO.actualizar(empleadoSelected);
+                if (domicilioEmpleadoSelected.getEmpleado() == null) {
+                    this.domicilioEmpleadoSelected.setEmpleado(empleadoSelected);
+                    this.domicilioEmpleadoDAO.guardar(this.domicilioEmpleadoSelected);
+                } else {
+                    log.trace("Información del domicilio {}", this.domicilioEmpleadoSelected.toString());
+                    this.domicilioEmpleadoDAO.actualizar(domicilioEmpleadoSelected);
                 }
-                
-                if(this.domicilioEmpleadoSelected.getNumeroExterior() == null)
-                {
-                    log.error("No se capturo el numero exterior");
-                    throw new SGPException("Debe indicar un numero de calle exterior");
+            }
+
+            if (this.empleadoFoto != null) {
+                empleadoFotoDAO.actualizar(empleadoFoto);
+            }
+
+            if (biometrico != null) {
+                detBiometrico.setIdEmpleado(empleadoSelected);
+                if (detBiometrico.getIdBiometrico() == null) {
+                    biometricoDAO.guardar(detBiometrico);
+                } else {
+                    biometricoDAO.actualizar(detBiometrico);
                 }
-                
-                if(this.datoEmpresa.getFechaIngreso() == null)
-                {
-                    log.error("Falta fecha de ingreso en dato empresa");
-                    throw new SGPException("Debe indicar la fecha de ingreso");
-                }
-                
-                if(this.datoEmpresa.getFechaIngreso() == null)
-                {
-                    log.error("Falta fecha de ingreso");
-                    throw new SGPException("Debe indicar una fecha de ingreso");
-                }
-                
-                if (this.empleadoSelected.getIdEmpleado() == null) {
-    			pNumeroEmpleado = this.parametroDAO.buscarPorClave("NBEMP");
-    			sNumeroEmpleado = pNumeroEmpleado.getValor();
-        		numeroEmpleado = Integer.parseInt(sNumeroEmpleado);
-        		sNumeroEmpleado = String.format("%04d", ++numeroEmpleado);
-                        transformarAMayusculas();
-        		this.empleadoSelected.setNumEmpleado(sNumeroEmpleado);
-        		this.empleadoSelected.setDatoEmpresa(this.datoEmpresa);
-        		this.empleadoSelected.setFechaRegistro(new Date());
-    			empleadoDAO.guardar(empleadoSelected);
-                        this.domicilioEmpleadoSelected.setEmpleado(this.empleadoSelected);
-                        this.domicilioEmpleadoDAO.guardar(domicilioEmpleadoSelected);
-                        pNumeroEmpleado.setValor(sNumeroEmpleado);
-                        this.parametroDAO.actualizar(pNumeroEmpleado);
-    		} else {
-    			empleadoDAO.actualizar(empleadoSelected);
-                        if(domicilioEmpleadoSelected.getEmpleado() == null)
-                        {
-                            this.domicilioEmpleadoSelected.setEmpleado(empleadoSelected);
-                            this.domicilioEmpleadoDAO.guardar(this.domicilioEmpleadoSelected);
-                        }else{
-                            log.trace("Información del domicilio {}", this.domicilioEmpleadoSelected.toString());
-                            this.domicilioEmpleadoDAO.actualizar(domicilioEmpleadoSelected);
-                        }
-                }
-    		
-    		if(this.empleadoFoto != null) {
-    			empleadoFotoDAO.actualizar(empleadoFoto);
-    		}
-    		
-    		if (biometrico != null) {
-    			detBiometrico.setIdEmpleado(empleadoSelected);
-    			if (detBiometrico.getIdBiometrico() == null) {
-    				biometricoDAO.guardar(detBiometrico);
-    			} else {
-    				biometricoDAO.actualizar(detBiometrico);
-    			}
                 biometrico = null;
             }
-    		
-	        consultaEmpleados();
-	        PrimeFaces.current().executeScript("PF('dialogEmpleado').hide()");
-    		mensaje = "El empleado se guardó correctamente.";
-    		severity = FacesMessage.SEVERITY_INFO;
-                
-    	} catch(SGPException ex) {
-    		mensaje = ex.getMessage();
-    		severity = FacesMessage.SEVERITY_WARN;
-    	} catch(Exception ex) {
-    		log.error("Problema para guardar información del empleado...", ex);
-    		mensaje = "Problema para guardar al empleado.";
-    		severity = FacesMessage.SEVERITY_ERROR;
-    	} finally {
+
+            consultaEmpleados();
+            PrimeFaces.current().executeScript("PF('dialogEmpleado').hide()");
+            mensaje = "El empleado se guardó correctamente.";
+            severity = FacesMessage.SEVERITY_INFO;
+
+        } catch (SGPException ex) {
+            mensaje = ex.getMessage();
+            severity = FacesMessage.SEVERITY_WARN;
+        } catch (Exception ex) {
+            log.error("Problema para guardar información del empleado...", ex);
+            mensaje = "Problema para guardar al empleado.";
+            severity = FacesMessage.SEVERITY_ERROR;
+        } finally {
             message = new FacesMessage(severity, titulo, mensaje);
             limpiarVariables();
             FacesContext.getCurrentInstance().addMessage(null, message);
-            PrimeFaces.current().ajax().update("formRegistroEmpleado:messages", "formRegistroEmpleado:panelDialogEmpleado");	
-    	}
+            PrimeFaces.current().ajax().update("formRegistroEmpleado:messages", "formRegistroEmpleado:panelDialogEmpleado");
+        }
     }
 
     /*
@@ -565,10 +569,11 @@ public class RegistroEmpleadosBean implements Serializable {
         List<String> numEmpl = new ArrayList<>();
         try {
             for (DetEmpleado empleado : lstEmpleadosSelected) {
-            	
-            	if(empleado.getDatoEmpresa() != null)
-            		empleado.getDatoEmpresa().setFechaBaja(new Date());
-            	
+
+                if (empleado.getDatoEmpresa() != null) {
+                    empleado.getDatoEmpresa().setFechaBaja(new Date());
+                }
+
                 empleadoDAO.eliminar(empleado);
                 numEmpl.add(empleado.getNumEmpleado());
             }
@@ -583,9 +588,9 @@ public class RegistroEmpleadosBean implements Serializable {
         PrimeFaces.current().ajax().update("formRegistroEmpleado:messages", "formRegistroEmpleado:dtEmpleados");
         this.lstEmpleadosSelected.clear();
     }
-    
+
     public void sinFoto() {
-    	this.empleadoFoto = null;
+        this.empleadoFoto = null;
     }
 
     /*
@@ -593,9 +598,9 @@ public class RegistroEmpleadosBean implements Serializable {
      */
     public void eliminaEmpleado() {
         try {
-        	this.empleadoSelected.setActivo((short)0);
-        	this.empleadoSelected.setFechaModificacion(new Date());
-        	empleadoDAO.actualizar(empleadoSelected);
+            this.empleadoSelected.setActivo((short) 0);
+            this.empleadoSelected.setFechaModificacion(new Date());
+            empleadoDAO.actualizar(empleadoSelected);
             consultaEmpleados();
             FacesContext.getCurrentInstance().addMessage(null, new FacesMessage("Empleado Eliminado"));
         } catch (SGPException ex) {
@@ -605,18 +610,18 @@ public class RegistroEmpleadosBean implements Serializable {
         }
         PrimeFaces.current().ajax().update("formRegistroEmpleado:messages", "formRegistroEmpleado:dtEmpleados");
     }
- 
+
     public String redirectKardex() {
         String redirect = "/protected/kardexEmpleado.xhtml?faces-redirect=true&idEmpleado=" + empleadoSelected.getIdEmpleado();
         return redirect;
     }
 
     public void oncapture(CaptureEvent captureEvent) {
-    	if(this.empleadoFoto == null) {
-    		this.empleadoFoto = new DetEmpleadoFoto();
-    		this.empleadoSelected.setEmpleadoFoto(empleadoFoto);
-    	}
-    	
+        if (this.empleadoFoto == null) {
+            this.empleadoFoto = new DetEmpleadoFoto();
+            this.empleadoSelected.setEmpleadoFoto(empleadoFoto);
+        }
+
         this.empleadoFoto.setFotografia("data:image/jpeg;base64," + Base64.getEncoder().encodeToString(captureEvent.getData()));
     }
 
@@ -625,34 +630,28 @@ public class RegistroEmpleadosBean implements Serializable {
         PrimeFaces.current().executeScript("PF('dialogBiometrico').show()");
     }
 
-    public void validaHuella() 
-    {
-        try
-        {
-            if (biometrico == null) 
-            {
+    public void validaHuella() {
+        try {
+            if (biometrico == null) {
                 throw new SGPException("Error al asignar biométrico");
             }
-        
+
             asignarBiometricos();
             FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_INFO, "Éxito", "Huella asignada"));
-        }catch (SGPException ex) 
-        {
+        } catch (SGPException ex) {
             log.warn("EX-0019: Error al consultar por huella al empleado " + detBiometrico.getIdEmpleado().getNumEmpleado() != null ? detBiometrico.getIdEmpleado().getNumEmpleado() : null + " y " + ex.getMessage());
             FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", "Error al asignar biométrico"));
-        }finally
-        {
+        } finally {
             PrimeFaces.current().ajax().update("formRegistroEmpleado:messages", "formRegistroEmpleado:panelDialogBiometrico");
         }
     }
-    
-    public void asignarBiometricos()
-    {
-        if(this.detBiometrico == null)
+
+    public void asignarBiometricos() {
+        if (this.detBiometrico == null) {
             this.detBiometrico = new DetBiometrico();
-        
-        switch(numBiometrico)
-        {
+        }
+
+        switch (numBiometrico) {
             case 1:
                 detBiometrico.setHuella(biometrico);
                 break;
@@ -660,37 +659,33 @@ public class RegistroEmpleadosBean implements Serializable {
                 detBiometrico.setHuella2(biometrico);
                 break;
         }
-        
+
         detBiometrico.setActivo((short) 1);
         detBiometrico.setFechaCaptura(new Date());
     }
-    
-    public List<CatAsentamiento> sugerenciasCodigoPostal(String consulta) 
-    {
+
+    public List<CatAsentamiento> sugerenciasCodigoPostal(String consulta) {
         List<CatAsentamiento> listaSugerencias = asentamientoDAO.buscarPorCodigoPostal(consulta);
         return listaSugerencias;
     }
-    
-    public void domicilioEmpleado() 
-    {   
-        log.info("Agregando/Actualizando información al domicilio");    
+
+    public void domicilioEmpleado() {
+        log.info("Agregando/Actualizando información al domicilio");
         this.agregarAsentamientoADomicilio(this.asentamientoSelected);
-        
+
         log.trace("Domicilio seleccionado: {}", this.domicilioEmpleadoSelected.toString());
         log.trace("Asentamiento seleccionado: {}", this.asentamientoSelected.toString());
-        
+
         FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_INFO, "Informacion", "Se actualizo el asentamiento"));
         PrimeFaces.current().ajax().update("formRegistroEmpleado:messages");
     }
-    
-    public void limpiarVariables() 
-    {
+
+    public void limpiarVariables() {
         this.domicilioEmpleadoSelected = null;
         this.asentamientoSelected = null;
     }
-    
-    public CatAsentamiento inicializarAsentamiento()
-    {
+
+    public CatAsentamiento inicializarAsentamiento() {
         CatAsentamiento aux = new CatAsentamiento();
         aux.setKey(new CatAsentamientoPK());
         aux.getKey().setLocalidad(new CatLocalidad());
@@ -702,14 +697,13 @@ public class RegistroEmpleadosBean implements Serializable {
         aux.getKey().getLocalidad().getKey().getMunicipio().getKey().getEstado().getKey().setPais(new Pais());
         return aux;
     }
-    
-    public void transformarAMayusculas()
-    {
+
+    public void transformarAMayusculas() {
         String nombre = this.empleadoSelected.getNombre().toUpperCase();
         String apellidoPa = this.empleadoSelected.getPrimerAp().toUpperCase();
         String apellidoMa = this.empleadoSelected.getSegundoAp().toUpperCase();
         String curp = this.empleadoSelected.getCurp().toUpperCase();
-        
+
         this.empleadoSelected.setNombre(nombre);
         this.empleadoSelected.setPrimerAp(apellidoPa);
         this.empleadoSelected.setSegundoAp(apellidoMa);
@@ -795,7 +789,7 @@ public class RegistroEmpleadosBean implements Serializable {
     public void setNumBiometrico(int numBiometrico) {
         this.numBiometrico = numBiometrico;
     }
-    
+
     public DetBiometrico getDetBiometrico() {
         return detBiometrico;
     }
@@ -804,133 +798,133 @@ public class RegistroEmpleadosBean implements Serializable {
         this.detBiometrico = detBiometrico;
     }
 
-	public InfDatoEmpresa getDatoEmpresa() {
-		return datoEmpresa;
-	}
+    public InfDatoEmpresa getDatoEmpresa() {
+        return datoEmpresa;
+    }
 
-	public void setDatoEmpresa(InfDatoEmpresa datoEmpresa) {
-		this.datoEmpresa = datoEmpresa;
-	}
+    public void setDatoEmpresa(InfDatoEmpresa datoEmpresa) {
+        this.datoEmpresa = datoEmpresa;
+    }
 
-	public List<CatTipoContrato> getTiposContrato() {
-		return tiposContrato;
-	}
+    public List<CatTipoContrato> getTiposContrato() {
+        return tiposContrato;
+    }
 
-	public void setTiposContrato(List<CatTipoContrato> tiposContrato) {
-		this.tiposContrato = tiposContrato;
-	}
+    public void setTiposContrato(List<CatTipoContrato> tiposContrato) {
+        this.tiposContrato = tiposContrato;
+    }
 
-	public List<CatTipoJornada> getTiposJornada() {
-		return tiposJornada;
-	}
+    public List<CatTipoJornada> getTiposJornada() {
+        return tiposJornada;
+    }
 
-	public void setTiposJornada(List<CatTipoJornada> tiposJornada) {
-		this.tiposJornada = tiposJornada;
-	}
+    public void setTiposJornada(List<CatTipoJornada> tiposJornada) {
+        this.tiposJornada = tiposJornada;
+    }
 
-	public List<CatTipoRegimen> getTiposRegimen() {
-		return tiposRegimen;
-	}
+    public List<CatTipoRegimen> getTiposRegimen() {
+        return tiposRegimen;
+    }
 
-	public void setTiposRegimen(List<CatTipoRegimen> tiposRegimen) {
-		this.tiposRegimen = tiposRegimen;
-	}
+    public void setTiposRegimen(List<CatTipoRegimen> tiposRegimen) {
+        this.tiposRegimen = tiposRegimen;
+    }
 
-	public String getRfc() {
-		return rfc;
-	}
+    public String getRfc() {
+        return rfc;
+    }
 
-	public void setRfc(String rfc) {
-		this.rfc = rfc;
-	}
+    public void setRfc(String rfc) {
+        this.rfc = rfc;
+    }
 
-	public String getCurp() {
-		return curp;
-	}
+    public String getCurp() {
+        return curp;
+    }
 
-	public void setCurp(String curp) {
-		this.curp = curp;
-	}
+    public void setCurp(String curp) {
+        this.curp = curp;
+    }
 
-	public String getNss() {
-		return nss;
-	}
+    public String getNss() {
+        return nss;
+    }
 
-	public void setNss(String nss) {
-		this.nss = nss;
-	}
+    public void setNss(String nss) {
+        this.nss = nss;
+    }
 
-	public DetEmpleadoFoto getEmpleadoFoto() {
-		return empleadoFoto;
-	}
+    public DetEmpleadoFoto getEmpleadoFoto() {
+        return empleadoFoto;
+    }
 
-	public void setEmpleadoFoto(DetEmpleadoFoto empleadoFoto) {
-		this.empleadoFoto = empleadoFoto;
-	}
+    public void setEmpleadoFoto(DetEmpleadoFoto empleadoFoto) {
+        this.empleadoFoto = empleadoFoto;
+    }
 
-	public List<CatEntidadFederativa> getEntidadesFederativas() {
-		return entidadesFederativas;
-	}
+    public List<CatEntidadFederativa> getEntidadesFederativas() {
+        return entidadesFederativas;
+    }
 
-	public void setEntidadesFederativas(List<CatEntidadFederativa> entidadesFederativas) {
-		this.entidadesFederativas = entidadesFederativas;
-	}
+    public void setEntidadesFederativas(List<CatEntidadFederativa> entidadesFederativas) {
+        this.entidadesFederativas = entidadesFederativas;
+    }
 
-	public List<CatRiesgoPuesto> getRiesgosPuesto() {
-		return riesgosPuesto;
-	}
+    public List<CatRiesgoPuesto> getRiesgosPuesto() {
+        return riesgosPuesto;
+    }
 
-	public void setRiesgosPuesto(List<CatRiesgoPuesto> riesgosPuesto) {
-		this.riesgosPuesto = riesgosPuesto;
-	}
+    public void setRiesgosPuesto(List<CatRiesgoPuesto> riesgosPuesto) {
+        this.riesgosPuesto = riesgosPuesto;
+    }
 
-	public List<CatPeriodicidadPago> getPeriodicidadesPago() {
-		return periodicidadesPago;
-	}
+    public List<CatPeriodicidadPago> getPeriodicidadesPago() {
+        return periodicidadesPago;
+    }
 
-	public void setPeriodicidadesPago(List<CatPeriodicidadPago> periodicidadesPago) {
-		this.periodicidadesPago = periodicidadesPago;
-	}
+    public void setPeriodicidadesPago(List<CatPeriodicidadPago> periodicidadesPago) {
+        this.periodicidadesPago = periodicidadesPago;
+    }
 
-	public List<DetPercepcionEmpleado> getPercepcionesEmpleado() {
-		return percepcionesEmpleado;
-	}
+    public List<DetPercepcionEmpleado> getPercepcionesEmpleado() {
+        return percepcionesEmpleado;
+    }
 
-	public void setPercepcionesEmpleado(List<DetPercepcionEmpleado> percepcionesEmpleado) {
-		this.percepcionesEmpleado = percepcionesEmpleado;
-	}
+    public void setPercepcionesEmpleado(List<DetPercepcionEmpleado> percepcionesEmpleado) {
+        this.percepcionesEmpleado = percepcionesEmpleado;
+    }
 
-	public List<CatTipoPercepcion> getTiposPercepcion() {
-		return tiposPercepcion;
-	}
+    public List<CatTipoPercepcion> getTiposPercepcion() {
+        return tiposPercepcion;
+    }
 
-	public void setTiposPercepcion(List<CatTipoPercepcion> tiposPercepcion) {
-		this.tiposPercepcion = tiposPercepcion;
-	}
+    public void setTiposPercepcion(List<CatTipoPercepcion> tiposPercepcion) {
+        this.tiposPercepcion = tiposPercepcion;
+    }
 
-	public DetPercepcionEmpleado getPercepcionEmpleado() {
-		return percepcionEmpleado;
-	}
+    public DetPercepcionEmpleado getPercepcionEmpleado() {
+        return percepcionEmpleado;
+    }
 
-	public void setPercepcionEmpleado(DetPercepcionEmpleado percepcionEmpleado) {
-		this.percepcionEmpleado = percepcionEmpleado;
-	}
+    public void setPercepcionEmpleado(DetPercepcionEmpleado percepcionEmpleado) {
+        this.percepcionEmpleado = percepcionEmpleado;
+    }
 
-	public List<CatTipoPrestamo> getTiposPrestamo() {
-		return tiposPrestamo;
-	}
+    public List<CatTipoPrestamo> getTiposPrestamo() {
+        return tiposPrestamo;
+    }
 
-	public void setTiposPrestamo(List<CatTipoPrestamo> tiposPrestamo) {
-		this.tiposPrestamo = tiposPrestamo;
-	}
+    public void setTiposPrestamo(List<CatTipoPrestamo> tiposPrestamo) {
+        this.tiposPrestamo = tiposPrestamo;
+    }
 
-	public DetPrestamo getPrestamo() {
-		return prestamo;
-	}
+    public DetPrestamo getPrestamo() {
+        return prestamo;
+    }
 
-	public void setPrestamo(DetPrestamo prestamo) {
-		this.prestamo = prestamo;
-	}
+    public void setPrestamo(DetPrestamo prestamo) {
+        this.prestamo = prestamo;
+    }
 
     public List<CatAsentamiento> getLstAsentamientos() {
         return lstAsentamientos;
@@ -947,7 +941,7 @@ public class RegistroEmpleadosBean implements Serializable {
     public void setLstDomicilios(List<DetDomicilioEmpleado> lstDomicilios) {
         this.lstDomicilios = lstDomicilios;
     }
-    
+
     public CatAsentamiento getAsentamientoSelected() {
         return asentamientoSelected;
     }
@@ -955,7 +949,7 @@ public class RegistroEmpleadosBean implements Serializable {
     public void setAsentamientoSelected(CatAsentamiento asentamientoSeleccionado) {
         this.asentamientoSelected = asentamientoSeleccionado;
     }
-    
+
     public String getCodigoPostal() {
         return codigoPostal;
     }
@@ -964,14 +958,82 @@ public class RegistroEmpleadosBean implements Serializable {
         this.codigoPostal = codigoPostal;
     }
 
-    public DetDomicilioEmpleado getDomicilioEmpleadoSelected() 
-    {
+    public DetDomicilioEmpleado getDomicilioEmpleadoSelected() {
         return domicilioEmpleadoSelected;
     }
 
-    public void setDomicilioEmpleadoSelected(DetDomicilioEmpleado domicilioEmpleadoSelected) 
-    {
+    public void setDomicilioEmpleadoSelected(DetDomicilioEmpleado domicilioEmpleadoSelected) {
         this.domicilioEmpleadoSelected = domicilioEmpleadoSelected;
     }
 
+    public CatPlanta getPlantaselected() {
+        return plantaselected;
+    }
+
+    public void setPlantaselected(CatPlanta plantaselected) {
+        this.plantaselected = plantaselected;
+    }
+
+    public CatEmpresa getEmpresaselected() {
+        return empresaselected;
+    }
+
+    public void setEmpresaselected(CatEmpresa empresaselected) {
+        this.empresaselected = empresaselected;
+    }
+
+    public boolean isActivo() {
+        return activo;
+    }
+
+    public void setActivo(boolean activo) {
+        this.activo = activo;
+    }
+
+    public boolean isInactivo() {
+        return inactivo;
+    }
+
+    public void setInactivo(boolean inactivo) {
+        this.inactivo = inactivo;
+    }
+
+    public List<DetEmpleado> filtrarEmpleados() {
+
+        if (this.empresaselected == null && this.plantaselected == null) {
+            return this.lstEmpleados;
+        }
+
+        if (this.empresaselected != null && this.plantaselected == null) {
+
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa().getIdEmpresa().equals(this.empresaselected.getIdEmpresa())).
+                    collect(Collectors.toList());
+
+        }
+
+        if (this.plantaselected != null && this.empresaselected == null) {
+
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getPlanta() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getPlanta().getIdPlanta().equals(this.plantaselected.getIdPlanta())).
+                    collect(Collectors.toList());
+
+        }
+
+        if (this.empresaselected != null && this.plantaselected != null) {
+
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa() != null && empleado.getDatoEmpresa().getPlanta() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa().getIdEmpresa().equals(this.empresaselected.getIdEmpresa()) && empleado.getDatoEmpresa().getPlanta().getIdPlanta().equals(this.plantaselected.getIdPlanta())).
+                    collect(Collectors.toList());
+
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/mx/com/ferbo/controller/RegistroEmpleadosBean.java
+++ b/src/main/java/mx/com/ferbo/controller/RegistroEmpleadosBean.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
@@ -71,6 +72,7 @@ import mx.com.ferbo.model.sat.CatTipoJornada;
 import mx.com.ferbo.model.sat.CatTipoPercepcion;
 import mx.com.ferbo.model.sat.CatTipoRegimen;
 import mx.com.ferbo.util.SGPException;
+import org.primefaces.util.LangUtils;
 
 @Named(value = "registroEmpleadosBean")
 @ViewScoped
@@ -126,8 +128,6 @@ public class RegistroEmpleadosBean implements Serializable {
     private boolean activo;
     private boolean inactivo;
 
-    private Date fechaactual;
-
     private DetEmpleado empleadoSelected;
     private DetBiometrico detBiometrico;
     private DetEmpleadoFoto empleadoFoto;
@@ -142,6 +142,8 @@ public class RegistroEmpleadosBean implements Serializable {
     private String rfc;
     private String nss;
     private String codigoPostal;
+    
+    private String texto;
 
     public RegistroEmpleadosBean() {
         empleadoFotoDAO = new EmpleadoFotoDAO(DetEmpleadoFoto.class);
@@ -1000,16 +1002,18 @@ public class RegistroEmpleadosBean implements Serializable {
         this.inactivo = inactivo;
     }
 
-    private Date getFechaactual() {
-        return fechaactual;
+    public String getTexto() {
+        return texto;
     }
 
-    private void setFechaactual(Date fechaactual) {
-        this.fechaactual = fechaactual;
+    public void setTexto(String texto) {
+        this.texto = texto;
     }
 
+    
+    
     public List<DetEmpleado> filtrarEmpleados() {
-
+        
         if (this.activo && this.inactivo && this.empresaselected == null && this.plantaselected == null) {
             return this.lstEmpleados;
         }
@@ -1122,7 +1126,6 @@ public class RegistroEmpleadosBean implements Serializable {
                     filter(empleado -> empleado.getDatoEmpresa().getPlanta() != null).
                     filter(empleado -> empleado.getDatoEmpresa().getPlanta().getIdPlanta().equals(this.plantaselected.getIdPlanta())).
                     collect(Collectors.toList());
-
         }
 
         if (this.empresaselected != null && this.plantaselected != null) {
@@ -1133,6 +1136,14 @@ public class RegistroEmpleadosBean implements Serializable {
                     collect(Collectors.toList());
         }
 
+                if(this.texto != null && !this.texto.equals("")){
+            
+            return this.lstEmpleados.stream().
+                    filter( empleado -> empleado.getNombre().contains(this.texto.trim().toUpperCase()) || empleado.getPrimerAp().contains(this.texto.trim().toUpperCase()) || empleado.getSegundoAp().contains(this.texto.trim().toUpperCase())).
+                    collect(Collectors.toList());
+        }
+
+        
         return null;
-    }
+    }  
 }

--- a/src/main/java/mx/com/ferbo/controller/RegistroEmpleadosBean.java
+++ b/src/main/java/mx/com/ferbo/controller/RegistroEmpleadosBean.java
@@ -125,7 +125,9 @@ public class RegistroEmpleadosBean implements Serializable {
     private CatEmpresa empresaselected;
     private boolean activo;
     private boolean inactivo;
-    
+
+    private Date fechaactual;
+
     private DetEmpleado empleadoSelected;
     private DetBiometrico detBiometrico;
     private DetEmpleadoFoto empleadoFoto;
@@ -998,24 +1000,123 @@ public class RegistroEmpleadosBean implements Serializable {
         this.inactivo = inactivo;
     }
 
+    private Date getFechaactual() {
+        return fechaactual;
+    }
+
+    private void setFechaactual(Date fechaactual) {
+        this.fechaactual = fechaactual;
+    }
+
     public List<DetEmpleado> filtrarEmpleados() {
 
-        if (this.empresaselected == null && this.plantaselected == null) {
+        if (this.activo && this.inactivo && this.empresaselected == null && this.plantaselected == null) {
             return this.lstEmpleados;
         }
 
-        if (this.empresaselected != null && this.plantaselected == null) {
-
+        if (this.activo && this.inactivo && this.empresaselected != null && this.plantaselected == null) {
             return this.lstEmpleados.stream().
                     filter(empleado -> empleado.getDatoEmpresa() != null).
                     filter(empleado -> empleado.getDatoEmpresa().getEmpresa() != null).
                     filter(empleado -> empleado.getDatoEmpresa().getEmpresa().getIdEmpresa().equals(this.empresaselected.getIdEmpresa())).
                     collect(Collectors.toList());
+        }
+
+        if (this.activo && this.inactivo && this.plantaselected != null && this.empresaselected == null) {
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getPlanta() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getPlanta().getIdPlanta().equals(this.plantaselected.getIdPlanta())).
+                    collect(Collectors.toList());
+        }
+
+        if (this.activo && this.inactivo && this.empresaselected != null && this.plantaselected != null) {
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa() != null && empleado.getDatoEmpresa().getPlanta() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa().getIdEmpresa().equals(this.empresaselected.getIdEmpresa()) && empleado.getDatoEmpresa().getPlanta().getIdPlanta().equals(this.plantaselected.getIdPlanta())).
+                    collect(Collectors.toList());
+        }
+
+        if (this.activo && this.empresaselected == null && this.plantaselected == null) {
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getFechaBaja() == null).
+                    collect(Collectors.toList());
+        }
+
+        if (this.inactivo && this.empresaselected == null && this.plantaselected == null) {
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getFechaBaja() != null).
+                    collect(Collectors.toList());
 
         }
 
-        if (this.plantaselected != null && this.empresaselected == null) {
+        if (this.activo && this.empresaselected != null && this.plantaselected == null) {
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa().getIdEmpresa().equals(this.empresaselected.getIdEmpresa())).
+                    filter(empleado -> empleado.getDatoEmpresa().getFechaBaja() == null).
+                    collect(Collectors.toList());
 
+        }
+
+        if (this.inactivo && this.empresaselected != null && this.plantaselected == null) {
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa().getIdEmpresa().equals(this.empresaselected.getIdEmpresa())).
+                    filter(empleado -> empleado.getDatoEmpresa().getFechaBaja() != null).
+                    collect(Collectors.toList());
+        }
+
+        if (this.activo && this.plantaselected != null && this.empresaselected == null) {
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getPlanta() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getPlanta().getIdPlanta().equals(this.plantaselected.getIdPlanta())).
+                    filter(empleado -> empleado.getDatoEmpresa().getFechaBaja() == null).
+                    collect(Collectors.toList());
+        }
+
+        if (this.inactivo && this.plantaselected != null && this.empresaselected == null) {
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getPlanta() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getPlanta().getIdPlanta().equals(this.plantaselected.getIdPlanta())).
+                    filter(empleado -> empleado.getDatoEmpresa().getFechaBaja() != null).
+                    collect(Collectors.toList());
+        }
+
+        if (this.activo && this.empresaselected != null && this.plantaselected != null) {
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa() != null && empleado.getDatoEmpresa().getPlanta() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa().getIdEmpresa().equals(this.empresaselected.getIdEmpresa()) && empleado.getDatoEmpresa().getPlanta().getIdPlanta().equals(this.plantaselected.getIdPlanta())).
+                    filter(empleado -> empleado.getDatoEmpresa().getFechaBaja() == null).
+                    collect(Collectors.toList());
+        }
+
+        if (this.inactivo && this.empresaselected != null && this.plantaselected != null) {
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa() != null && empleado.getDatoEmpresa().getPlanta() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa().getIdEmpresa().equals(this.empresaselected.getIdEmpresa()) && empleado.getDatoEmpresa().getPlanta().getIdPlanta().equals(this.plantaselected.getIdPlanta())).
+                    filter(empleado -> empleado.getDatoEmpresa().getFechaBaja() != null).
+                    collect(Collectors.toList());
+        }
+
+        if (this.empresaselected != null && this.plantaselected == null) {
+            return this.lstEmpleados.stream().
+                    filter(empleado -> empleado.getDatoEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa() != null).
+                    filter(empleado -> empleado.getDatoEmpresa().getEmpresa().getIdEmpresa().equals(this.empresaselected.getIdEmpresa())).
+                    collect(Collectors.toList());
+        }
+
+        if (this.plantaselected != null && this.empresaselected == null) {
             return this.lstEmpleados.stream().
                     filter(empleado -> empleado.getDatoEmpresa() != null).
                     filter(empleado -> empleado.getDatoEmpresa().getPlanta() != null).
@@ -1025,13 +1126,11 @@ public class RegistroEmpleadosBean implements Serializable {
         }
 
         if (this.empresaselected != null && this.plantaselected != null) {
-
             return this.lstEmpleados.stream().
                     filter(empleado -> empleado.getDatoEmpresa() != null).
                     filter(empleado -> empleado.getDatoEmpresa().getEmpresa() != null && empleado.getDatoEmpresa().getPlanta() != null).
                     filter(empleado -> empleado.getDatoEmpresa().getEmpresa().getIdEmpresa().equals(this.empresaselected.getIdEmpresa()) && empleado.getDatoEmpresa().getPlanta().getIdPlanta().equals(this.plantaselected.getIdPlanta())).
                     collect(Collectors.toList());
-
         }
 
         return null;

--- a/src/main/webapp/protected/registroEmpleado.xhtml
+++ b/src/main/webapp/protected/registroEmpleado.xhtml
@@ -10,20 +10,46 @@
     </ui:define>
     <ui:define name="content">
         <h:form id="formRegistroEmpleado">
-			<p:growl id="messages" showDetail="true" life="2500"/>
-			<p:dialog modal="true" widgetVar="statusInfoDialog" header="Cargando información..." draggable="false" closable="false" resizable="false">
-				<div align="center">
-					<i class="pi pi-spinner pi-spin" style="font-size:3rem;"></i>
-				</div>
-			</p:dialog>
+            <p:growl id="messages" showDetail="true" life="2500"/>
+            <p:dialog modal="true" widgetVar="statusInfoDialog" header="Cargando información..." draggable="false" closable="false" resizable="false">
+                <div align="center">
+                    <i class="pi pi-spinner pi-spin" style="font-size:3rem;"></i>
+                </div>
+            </p:dialog>
             <div class="grid table-demo">
                 <div class="col-12">
                     <div class="card p-4">
-                         <p:blockUI block="formRegistroEmpleado:dialogBiometrico" widgetVar="bui"/>
-                         <p:remoteCommand name="verificaEstado" onstart="PF('bui').hide();" actionListener="#{registroEmpleadosBean.validaHuella()}"/>
+                        <p:blockUI block="formRegistroEmpleado:dialogBiometrico" widgetVar="bui"/>
+                        <p:remoteCommand name="verificaEstado" onstart="PF('bui').hide();" actionListener="#{registroEmpleadosBean.validaHuella()}"/>
                         <p:toolbar styleClass="mb-4">
                             <p:toolbarGroup>
                                 <p:commandButton value="Agregar" icon="pi pi-plus" actionListener="#{registroEmpleadosBean.agregarEmpleado()}" update="panelDialogEmpleado" oncomplete="PF('dialogEmpleado').show()" style="margin-right: .5rem" process="@this"/>
+                            </p:toolbarGroup>
+                            <p:toolbarGroup>
+                                <p:selectOneMenu id="onemenuplanta" value="#{registroEmpleadosBean.plantaselected}" converter="entityConverter">
+                                    <f:selectItem itemLabel="Todas las plantas" itemValue="#{null}"/>
+                                    <f:selectItems value="#{registroEmpleadosBean.lstCatPlanta}" var="planta" itemLabel="#{planta.descripcion}" itemValue="#{planta}"/>
+                                    <p:ajax event="change"  update="dtEmpleados" process="@this" />
+                                </p:selectOneMenu>
+                            </p:toolbarGroup>
+                            <p:toolbarGroup>
+                                <p:selectOneMenu id="onemenuempresa" value="#{registroEmpleadosBean.empresaselected}" converter="entityConverter">
+                                    <f:selectItem itemLabel="Todas las empresas" itemValue="#{null}"/>
+                                    <f:selectItems value="#{registroEmpleadosBean.lstCatEmpresa}" var="empresa" itemLabel="#{empresa.descripcion}" itemValue="#{empresa}"/>
+                                    <p:ajax event="change" update="dtEmpleados" process="@this" />
+                                </p:selectOneMenu>
+                            </p:toolbarGroup>
+                            <p:toolbarGroup>
+                                <p:outputLabel value="Activo "/>
+                                <p:toggleSwitch value="#{registroEmpleadosBean.activo}">
+                                    <p:ajax  update="dtEmpleados"/>
+                                </p:toggleSwitch>
+                            </p:toolbarGroup>
+                            <p:toolbarGroup>
+                                <p:outputLabel value="Inactivo "/>
+                                <p:toggleSwitch value="#{registroEmpleadosBean.inactivo}">
+                                    <p:ajax  update="dtEmpleados"/>
+                                </p:toggleSwitch>
                             </p:toolbarGroup>
                             <p:toolbarGroup align="right">
                                 <p:commandButton value="Descargar" icon="pi pi-download" styleClass="ui-button-secondary" ajax="false">
@@ -32,7 +58,7 @@
                             </p:toolbarGroup>
                         </p:toolbar>
 
-                        <p:dataTable id="dtEmpleados" widgetVar="dtEmpleados" var="empleado" value="#{registroEmpleadosBean.lstEmpleados}" reflow="true" styleClass="products-table"
+                        <p:dataTable id="dtEmpleados" widgetVar="dtEmpleados" var="empleado" value="#{registroEmpleadosBean.filtrarEmpleados()}" reflow="true" styleClass="products-table"
                                      selection="#{registroEmpleadosBean.lstEmpleadosSelected}" rowKey="#{empleado.idEmpleado}" paginator="true" rows="10" rowSelectMode="add" 
                                      paginatorPosition="bottom" lazy="true">
 
@@ -40,10 +66,10 @@
                                 <h:outputText value="#{empleado.numEmpleado}" styleClass="customer-badge status-#{empleado.activo eq 1 ? 'qualified': 'unqualified'}"/>
                             </p:column>
                             <p:column headerText="Primer Apellido" sortBy="#{empleado.primerAp}" filterBy="#{empleado.primerAp}">
-                            	<h:outputText style="vertical-alin: middle; margin-left: .5rem" value="#{empleado.primerAp}" />
+                                <h:outputText style="vertical-alin: middle; margin-left: .5rem" value="#{empleado.primerAp}" />
                             </p:column>
                             <p:column headerText="Segundo Apellido" sortBy="#{empleado.segundoAp}" filterBy="#{empleado.segundoAp}">
-                            	<h:outputText style="vertical-alin: middle; margin-left: .5rem" value="#{empleado.segundoAp}" />
+                                <h:outputText style="vertical-alin: middle; margin-left: .5rem" value="#{empleado.segundoAp}" />
                             </p:column>
                             <p:column headerText="Nombre" sortBy="#{empleado.nombre}" filterBy="#{empleado.nombre}">
                                 <h:outputText style="vertical-align: middle; margin-left: .5rem" value="#{empleado.nombre}" />
@@ -57,391 +83,391 @@
                                 </p:commandButton>
                             </p:column>
                         </p:dataTable>
-                        
+
                         <p:dialog header="Información..." showEffect="fade" modal="true" widgetVar="dialogEmpleado" responsive="true" resizable="false" width="100%" height="100%" position="center top" cache="false">
-							<p:tabView id="panelDialogEmpleado" class="ui-fluid" dynamic="true" effect="drop">
-                                                                <p:ajax event="tabChange" update="formRegistroEmpleado:panelDialogEmpleado formRegistroEmpleado:panelDialogEmpleado:previewFotografia" oncomplete="PF('dialogEmpleado').initPosition();"/>
-								<p:tab title="Personal">
-							        <h4>Información del empleado</h4>
-                                                                <div class="formgrid grid">
-							            <div class="field col-4">
-							                <p:outputLabel for="@next" value="Número de empleado"/>
-							                <p:inputText id="numEmp" value="#{registroEmpleadosBean.empleadoSelected.numEmpleado}" disabled="true"/>  
-							            </div>
-							        </div>
-							        <div class="formgrid grid">
-							            <div class="field col">
-							                <p:outputLabel for="@next" value="Nombre"/>
-							                <p:inputText id="nombreEmp" value="#{registroEmpleadosBean.empleadoSelected.nombre}" style="text-transform: uppercase">
-							                	<p:ajax process="@this" />
-							                </p:inputText>
-							            </div>
-							            <div class="field col">
-							                <p:outputLabel for="@next" value="Primer Apellido"/>
-							                <p:inputText id="primerAp" value="#{registroEmpleadosBean.empleadoSelected.primerAp}" style="text-transform: uppercase">
-							                	<p:ajax process="@this" />
-							                </p:inputText>
-							            </div>
-							            <div class="field col">
-							                <p:outputLabel for="@next" value="Segundo Apellido"/>
-							                <p:inputText id="segundoAp" value="#{registroEmpleadosBean.empleadoSelected.segundoAp}" style="text-transform: uppercase">
-							                	<p:ajax process="@this" />
-							                </p:inputText>
-							            </div>
-							        </div>
-							        <div class="formgrid grid">
-							            <div class="field col">
-							                <p:outputLabel for="@next" value="CURP"/>
-							                <p:inputText id="curp" value="#{registroEmpleadosBean.empleadoSelected.curp}" maxlength="18" style="text-transform: uppercase">
-							                	<p:ajax process="@this" />
-							                </p:inputText>  
-										</div>
-										<div class="field col">
-											<p:outputLabel for="@next" value="Fecha de nacimiento" />
-											<p:datePicker id="fNac" value="#{registroEmpleadosBean.empleadoSelected.fechaNacimiento}" monthNavigator="true" yearNavigator="true" yearRange="1940:2015" pattern="dd/MM/yyyy" showIcon="true" locale="es" timeZone="GMT-6">
-												<p:ajax process="@this" />
-											</p:datePicker>
-										</div>
-										<div class="field col">
-											<p:outputLabel for="@next" value="Correo"/>
-											<p:inputText id="correo" value="#{registroEmpleadosBean.empleadoSelected.correo}">
-												<p:ajax process="@this" />
-											</p:inputText>  
-										</div>
-									</div>
-									<h5>Domicilio</h5>
-									<div class="formgrid grid">
-									<div class="field col">
-										<p:outputLabel for="@next" value="Codigo Postal"/>
-										<p:autoComplete id="autocomplete" value="#{registroEmpleadosBean.asentamientoSelected}" completeMethod="#{registroEmpleadosBean.sugerenciasCodigoPostal}" 
-										    placeholder="Escribe el codigo postal..." var="sugerencia" itemLabel="#{sugerencia.cp}" itemValue="#{sugerencia}" 
-										    forceSelection="true"  minQueryLength="5" maxlength="5" converter="entityConverter" >
-											<p:ajax process="@this" event="itemSelect" listener="#{registroEmpleadosBean.domicilioEmpleado()}" update="pais estado municipio localidad asentamiento"/>
-											<p:column>
-												<p:outputLabel value="#{sugerencia.cp}"/>
-											</p:column>
-											<p:column>
-												<p:outputLabel value="#{sugerencia.descripcion}"/>
-											</p:column>
-										</p:autoComplete> 
-									</div>
-									<div class="field col">
-										<p:outputLabel for="@next" value="Pais" />
-										<p:inputText id="pais" value="#{registroEmpleadosBean.asentamientoSelected.key.localidad.key.municipio.key.estado.key.pais.nombrePais}" >
-											<p:ajax process="@this" />
-										</p:inputText>
-									</div>
-									<div class="field col">
-										<p:outputLabel for="@next" value="Estado" />
-										<p:inputText id="estado" value="#{registroEmpleadosBean.asentamientoSelected.key.localidad.key.municipio.key.estado.descripcion}" >
-											<p:ajax process="@this" />
-										</p:inputText>
-									</div>
-								</div>
-								<div class="formgrid grid">
-									<div class="field col">
-										<p:outputLabel for="@next" value="Municipio" />
-										<p:inputText id="municipio" value="#{registroEmpleadosBean.asentamientoSelected.key.localidad.key.municipio.descripcion}" >
-											<p:ajax process="@this" />
-										</p:inputText>
-									</div>
-									<div class="field col">
-										<p:outputLabel for="@next" value="Localidad" />
-										<p:inputText id="localidad" value="#{registroEmpleadosBean.asentamientoSelected.key.localidad.descripcion}" >
-											<p:ajax process="@this" />
-										</p:inputText>
-									</div>
-								    <div class="field col">
-								        <p:outputLabel for="@next" value="Asentamiento" />
-								        <p:inputText id="asentamiento" value="#{registroEmpleadosBean.asentamientoSelected.descripcion}" >
-								            <p:ajax process="@this" />
-								        </p:inputText>
-								    </div>
-								</div>
-								<div class="formgrid grid">
-									<div class="field col">
-										<p:outputLabel for="@next" value="Calle" />
-										<p:inputText id="calle" value="#{registroEmpleadosBean.domicilioEmpleadoSelected.calle}" >
-											<p:ajax process="@this" />
-										</p:inputText>
-									</div>
-									<div class="field col">
-										<p:outputLabel for="@next" value="Num. Ext." />
-										<p:inputText id="numExt" value="#{registroEmpleadosBean.domicilioEmpleadoSelected.numeroExterior}" >
-											<p:ajax process="@this" />
-										</p:inputText>
-									</div>
-									<div class="field col">
-										<p:outputLabel for="@next" value="Num. Int" />
-										<p:inputText id="numInt" value="#{registroEmpleadosBean.domicilioEmpleadoSelected.numeroInterior}" >
-											<p:ajax process="@this" />
-										</p:inputText>
-									</div>
-								</div>
-								</p:tab>
-								<p:tab title="Empresarial">
-									<div class="card">
-										<div class="ui-fluid formgrid grid">
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Fecha de ingreso" />
-								                <p:datePicker id="fIngreso" value="#{registroEmpleadosBean.datoEmpresa.fechaIngreso}" monthNavigator="true" yearNavigator="true" showIcon="true" locale="es_MX" timeZone="GMT-6" pattern="dd/MM/yyyy">
-								                	<p:ajax process="@this" />
-								                </p:datePicker>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Fecha de baja" />
-												<p:datePicker value="#{registroEmpleadosBean.datoEmpresa.fechaBaja}" showIcon="true" locale="es_MX" timeZone="GMT-6" pattern="dd/MM/yyyy">
-													<p:ajax process="@this" />
-												</p:datePicker>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="RFC" />
-												<p:inputText id="rfc" value="#{registroEmpleadosBean.datoEmpresa.rfc}" maxlength="18" style="text-transform: uppercase">
-													<p:ajax process="@this"/>
-												</p:inputText>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="NSS" />
-												<p:inputText id="nss" value="#{registroEmpleadosBean.datoEmpresa.nss}" maxlength="15" style="text-transform: uppercase">
-													<p:ajax process="@this"/>
-												</p:inputText>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Salario Diario" />
-												<p:inputNumber id="salario" value="#{registroEmpleadosBean.datoEmpresa.salarioDiario}" symbol="$ " symbolPosition="p" decimalSeparator="." decimalPlaces="2">
-													<p:ajax process="@this"/>
-												</p:inputNumber>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Perfil" />
-								                <p:selectOneMenu id="soPerfil" value="#{registroEmpleadosBean.datoEmpresa.perfil}" autoWidth="false" converter="entityConverter">
-								                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
-								                    <f:selectItems value="#{registroEmpleadosBean.lstCatPerfil}" var="perfil" itemValue="#{perfil}" itemLabel="#{perfil.descripcion}"/>
-								                    <p:ajax process="@this"/>
-								                </p:selectOneMenu>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Empresa" />
-								                <p:selectOneMenu id="soEmpresa" value="#{registroEmpleadosBean.datoEmpresa.empresa}" autoWidth="false" converter="entityConverter">
-								                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
-								                    <f:selectItems value="#{registroEmpleadosBean.lstCatEmpresa}" var="empresa" itemValue="#{empresa}" itemLabel="#{empresa.descripcion}"/>
-								                    <p:ajax process="@this"/>
-								                </p:selectOneMenu>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Puesto" />
-							                <p:selectOneMenu id="soPuesto" value="#{registroEmpleadosBean.datoEmpresa.puesto}" autoWidth="false" converter="entityConverter">
-							                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
-							                    <f:selectItems value="#{registroEmpleadosBean.lstCatPuesto}" var="puesto" itemValue="#{puesto}" itemLabel="#{puesto.descripcion}"/>
-							                    <p:ajax process="@this"/>
-							                </p:selectOneMenu>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Área" />
-								                <p:selectOneMenu id="soArea" value="#{registroEmpleadosBean.datoEmpresa.area}" autoWidth="false" converter="entityConverter">
-								                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
-								                    <f:selectItems value="#{registroEmpleadosBean.lstCatArea}" var="area" itemValue="#{area}" itemLabel="#{area.descripcion}"/>
-								                    <p:ajax process="@this"/>
-								                </p:selectOneMenu>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Ubicación" />
-								                <p:selectOneMenu id="soUbica" value="#{registroEmpleadosBean.datoEmpresa.planta}" autoWidth="false" converter="entityConverter">
-								                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
-								                    <f:selectItems value="#{registroEmpleadosBean.lstCatPlanta}" var="planta" itemValue="#{planta}" itemLabel="#{planta.descripcion}"/>
-								                    <p:ajax process="@this"/>
-								                </p:selectOneMenu>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Tipo de contrato" />
-								            	<p:selectOneMenu id="soTipoContrato" value="#{registroEmpleadosBean.datoEmpresa.tipoContrato}" autoWidth="false" converter="entityConverter">
-								            		<f:selectItem itemLabel="--Seleccione--" noSelectionOption="true" />
-								            		<f:selectItems value="#{registroEmpleadosBean.tiposContrato}" var="tipoContrato" itemValue="#{tipoContrato}" itemLabel="#{tipoContrato.clave} - #{tipoContrato.nombre}" />
-								            		<p:ajax process="@this" />
-								            	</p:selectOneMenu>
-											</div>
-											
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Tipo de jornada" />
-												<p:selectOneMenu id="soTipoJornada" value="#{registroEmpleadosBean.datoEmpresa.tipoJornada}" autoWidth="false" converter="entityConverter">
-													<f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
-													<f:selectItems value="#{registroEmpleadosBean.tiposJornada}" var="tipoJornada" itemValue="#{tipoJornada}" itemLabel="#{tipoJornada.clave} - #{tipoJornada.nombre}"></f:selectItems>
-													<p:ajax process="@this" />
-												</p:selectOneMenu>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Tipo de régimen"/>
-												<p:selectOneMenu id="soTipoRegimen" value="#{registroEmpleadosBean.datoEmpresa.tipoRegimen}" autoWidth="false" converter="entityConverter">
-													<f:selectItem itemLabel="--Seleccione--" noSelectionOption="true" />
-													<f:selectItems value="#{registroEmpleadosBean.tiposRegimen}" var="tipoRegimen" itemValue="#{tipoRegimen}" itemLabel="#{tipoRegimen.clave} - #{tipoRegimen.nombre}"></f:selectItems>
-													<p:ajax process="@this" />
-												</p:selectOneMenu>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Hora de entrada" />
-												<p:datePicker value="#{registroEmpleadosBean.datoEmpresa.horaEntrada}" timeOnly="true" timeZone="GMT-6" locale="es">
-													<p:ajax process="@this" />
-												</p:datePicker>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Tolerancia (minutos)"></p:outputLabel>
-												<p:inputNumber value="#{registroEmpleadosBean.datoEmpresa.minutosTolerancia}">
-													<p:ajax process="@this" />
-												</p:inputNumber>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Código Postal"/>
-												<p:inputText value="#{registroEmpleadosBean.datoEmpresa.codigoPostal}" maxlength="5">
-													<p:ajax process="@this" />
-												</p:inputText>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Entidad Federativa" />
-												<p:selectOneMenu id="soEntidadFederativa" value="#{registroEmpleadosBean.datoEmpresa.entidadFederativa}" autoWidth="false" converter="entityConverter">
-													<f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
-													<f:selectItems value="#{registroEmpleadosBean.entidadesFederativas}" var="entidad" itemLabel="#{entidad.clave} - #{entidad.nombre}" itemValue="#{entidad}"/>
-													<p:ajax process="@this" />
-												</p:selectOneMenu>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Riesgo puesto" />
-												<p:selectOneMenu id="soRiesgoPuesto" value="#{registroEmpleadosBean.datoEmpresa.riesgoPuesto}" autoWidth="false" converter="entityConverter">
-													<f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
-													<f:selectItems value="#{registroEmpleadosBean.riesgosPuesto}" var="riesgo" itemLabel="#{riesgo.clave} - #{riesgo.descripcion}"/>
-													<p:ajax process="@this" />
-												</p:selectOneMenu>
-											</div>
-											<div class="field col-12 md:col-3">
-												<p:outputLabel for="@next" value="Periodicidad de pago" />
-												<p:selectOneMenu id="soPeriodicidadPago" value="#{registroEmpleadosBean.datoEmpresa.periodicidadPago}" autoWidth="false" converter="entityConverter">
-													<f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
-													<f:selectItems value="#{registroEmpleadosBean.periodicidadesPago}" var="periodicidad" itemLabel="#{periodicidad.periodicidad} - #{periodicidad.descripcion}" itemValue="#{periodicidad}"/>
-													<p:ajax process="@this" />
-												</p:selectOneMenu>
-											</div>
-											<div class="field col-12 md:col-1">
-												<p:outputLabel for="@next" value="Sindicalizado"/>
-												<p:selectBooleanButton value="#{registroEmpleadosBean.datoEmpresa.sindicalizado}" onLabel="Si" offLabel="No" onIcon="pi pi-check" offIcon="pi pi-times" style="width:6rem" />
-											</div>
-										</div>
-									</div>
-								</p:tab>
-								<p:tab title="Biométrica">
-									<div align="center">
-										<p:panelGrid columns="2">
-											<p:card>
-												<div class="field column">
-													<p:panelGrid columns="2">
-														<p:outputPanel id="previewFingerprint1">
-															<p:graphicImage rendered="#{empty registroEmpleadosBean.detBiometrico.huella}" name="images/huella/finger_print_01.png" library="recursos" style="max-height: 14rem;"/>
-		                                        			<p:graphicImage rendered="#{not empty registroEmpleadosBean.detBiometrico.huella}" name="images/huella/finger_print_02.png" library="recursos" style="max-height: 14rem;"/>
-														</p:outputPanel>
-														<p:outputPanel id="previewFingerprint2">
-															<p:graphicImage rendered="#{registroEmpleadosBean.detBiometrico eq null}" name="images/huella/finger_print_01.png" library="recursos" style="max-height: 14rem;"/>
-		                                        			<p:graphicImage rendered="#{registroEmpleadosBean.detBiometrico.huella2 ne null}" name="images/huella/finger_print_02.png" library="recursos" style="max-height: 14rem;"/>
-														</p:outputPanel>
-													</p:panelGrid>
-													<p:commandButton value="Capturar biométricos" icon="pi pi-sync" process="@this" actionListener="#{registroEmpleadosBean.consultaBiometrico()}" immediate="true"/>
-												</div>
-											</p:card>
-											<p:card>
-												<div class="card">
-													<p:outputPanel id="previewFotografia">
-														<p:graphicImage rendered="#{empty registroEmpleadosBean.empleadoFoto.fotografia}" library="recursos" name="images/user-icon.png" style="height: 15rem;" />
-														<img src="#{registroEmpleadosBean.empleadoFoto.fotografia}" style="height: 15rem;"/>
-													</p:outputPanel>
-													<p:commandButton value="Tomar fotografía" icon="pi pi-camera" process="@this" immediate="true" update="formRegistroEmpleado:photo" oncomplete="PF('dialogFotografia').show();" />
-												</div>
-											</p:card>
-										</p:panelGrid>
-									</div>
-								</p:tab>
-								<p:tab title="Percepciones">
-									<div class="ui-fluid formgrid grid">
-										<div class="field col-12 md:col-3">
-											<p:selectOneMenu id="selTipoPercepcion" value="#{registroEmpleadosBean.percepcionEmpleado.tipoPercepcion}" autoWidth="false" converter="entityConverter" filter="true" filterMatchMode="contains">
-												<f:selectItem itemLabel="---SELECCIONE UNA PERCEPCION---"/>
-												<f:selectItems value="#{registroEmpleadosBean.tiposPercepcion}" var="tipoPercepcion" itemLabel="#{tipoPercepcion.clave} - #{tipoPercepcion.descripcion}" itemValue="#{tipoPercepcion}"/>
-											</p:selectOneMenu>
-										</div>
-										<div class="field col-12 md:col-3">
-											<p:inputNumber id="txtImportePercepcion" value="#{registroEmpleadosBean.percepcionEmpleado.importeMaximo}" symbol="$ " decimalPlaces="2" decimalSeparator="." thousandSeparator="," placeholder="Importe máximo">
-												<p:ajax process="@this" />
-											</p:inputNumber>
-										</div>
-										<div class="field col-12 md:col-3">
-											<p:selectBooleanButton id="selPercepcionActivo" value="#{registroEmpleadosBean.percepcionEmpleado.activo}" onLabel="Activo" offLabel="Inactivo" onIcon="pi pi-check" offIcon="pi pi-times" style="width:6rem" disabled="false" />
-										</div>
-										<div class="field col-12 md:col-3">
-											<p:commandButton value="Agregar" actionListener="#{registroEmpleadosBean.agregarPercepcionEmpleado}" icon="pi pi-plus" update="dt-percepcion-empleado selTipoPercepcion txtImportePercepcion selPercepcionActivo"></p:commandButton>
-										</div>
-									</div>
-									<p:dataTable id="dt-percepcion-empleado" value="#{registroEmpleadosBean.percepcionesEmpleado}" var="percepcion" paginator="true" rows="5" paginatorPosition="bottom" lazy="true">
-										<p:column headerText="Percepcion">
-											<p:outputLabel value="#{percepcion.tipoPercepcion.clave} - #{percepcion.tipoPercepcion.descripcion}" />
-										</p:column>
-										<p:column headerText="Importe máximo" width="6rem">
-											<p:inputNumber value="#{percepcion.importeMaximo}" symbol="$ " decimalPlaces="2" decimalSeparator="." thousandSeparator=",">
-												<p:ajax process="@this" />
-											</p:inputNumber>
-										</p:column>
-										<p:column headerText="Activo" width="4rem">
-											<p:selectBooleanButton value="#{percepcion.activo}" onLabel="Si" offLabel="No" onIcon="pi pi-check" offIcon="pi pi-times" style="width:6rem"/>
-										</p:column>
-										<p:column width="2rem">
-											<p:commandButton icon="pi pi-trash" onclick="PF('dlgEliminarPercepcionEmpleado').show();" styleClass="ui-button-danger">
-												<f:setPropertyActionListener value="#{percepcion}" target="#{registroEmpleadosBean.percepcionEmpleado}"></f:setPropertyActionListener>
-											</p:commandButton>
-										</p:column>
-									</p:dataTable>
-								</p:tab>
-								<p:tab title="Préstamos">
-									<p:toolbar>
-										<p:toolbarGroup>
-											<p:commandButton value="Agregar" icon="pi pi-plus" oncomplete="PF('dgPrestamo').show();"></p:commandButton>
-										</p:toolbarGroup>
-									</p:toolbar>
-									<p:dataTable id="dt-prestamos" widgetVar="dtPrestamos" value="#{registroEmpleadosBean.empleadoSelected.prestamos}" var="prestamo" allowUnsorting="true" sortMode="single" reflow="true" lazy="true">
-										<p:column headerText="Fecha inicio" sortBy="#{prestamo.fechaInicio}">
-											<p:datePicker value="#{prestamo.fechaInicio}" monthNavigator="true" yearNavigator="true" showIcon="true" pattern="dd/MM/yyyy" locale="es" timeZone="GMT-6">
-												<p:ajax process="@this"></p:ajax>
-											</p:datePicker>
-										</p:column>
-										<p:column headerText="Fecha fin" sortBy="#{prestamo.fechaFin}">
-											<p:datePicker value="#{prestamo.fechaFin}" monthNavigator="true" yearNavigator="true" showIcon="true" pattern="dd/MM/yyyy" locale="es" timeZone="GMT-6">
-												<p:ajax process="@this"></p:ajax>
-											</p:datePicker>
-										</p:column>
-										<p:column headerText="Periodicidad de pago" width="auto">
-											<p:selectOneMenu value="#{prestamo.periodicidadPago}" converter="entityConverter" autoWidth="false">
-												<f:selectItem itemLabel="Seleccione la periodicidad de pago" noSelectionOption="true" />
-												<f:selectItems value="#{registroEmpleadosBean.periodicidadesPago}" var="periodicidad" itemLabel="#{periodicidad.descripcion}"></f:selectItems>
-											</p:selectOneMenu>
-										</p:column>
-										<p:column headerText="Tipo Préstamo">
-											<p:selectOneMenu value="#{prestamo.tipoPrestamo}" converter="entityConverter" autoWidth="false">
-												<f:selectItem itemLabel="Seleccione un tipo de préstamo" noSelectionOption="true" />
-												<f:selectItems value="#{registroEmpleadosBean.tiposPrestamo}" var="tipoPrestamo" itemLabel="#{tipoPrestamo.descripcion}" itemValue="#{tipoPrestamo}" />
-											</p:selectOneMenu>
-										</p:column>
-										<p:column headerText="Acumulado" width="5rem">
-											<p:inputNumber value="#{prestamo.acumulado}" decimalSeparator="2" symbol="$" symbolPosition="p" emptyValue="empty" />
-										</p:column>
-										<p:column headerText="Importe" width="5rem;">
-											<p:inputNumber value="#{prestamo.importe}" decimalSeparator="2" symbol="$" symbolPosition="p" emptyValue="empty" />
-										</p:column>
-										<p:column headerText="Total" width="5rem">
-											<p:inputNumber value="#{prestamo.total}" decimalSeparator="2" symbol="$" symbolPosition="p" emptyValue="empty" />
-										</p:column>
-										<p:column width="3rem;">
-											<p:commandButton icon="pi pi-trash" styleClass="ui-button-danger" oncomplete="PF('dlgEliminarPrestamo').show();">
-												<f:setPropertyActionListener value="#{prestamo}" target="#{registroEmpleadosBean.prestamo}"></f:setPropertyActionListener>
-											</p:commandButton>
-										</p:column>
-									</p:dataTable>
-								</p:tab>
-							</p:tabView>
-							
+                            <p:tabView id="panelDialogEmpleado" class="ui-fluid" dynamic="true" effect="drop">
+                                <p:ajax event="tabChange" update="formRegistroEmpleado:panelDialogEmpleado formRegistroEmpleado:panelDialogEmpleado:previewFotografia" oncomplete="PF('dialogEmpleado').initPosition();"/>
+                                <p:tab title="Personal">
+                                    <h4>Información del empleado</h4>
+                                    <div class="formgrid grid">
+                                        <div class="field col-4">
+                                            <p:outputLabel for="@next" value="Número de empleado"/>
+                                            <p:inputText id="numEmp" value="#{registroEmpleadosBean.empleadoSelected.numEmpleado}" disabled="true"/>  
+                                        </div>
+                                    </div>
+                                    <div class="formgrid grid">
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Nombre"/>
+                                            <p:inputText id="nombreEmp" value="#{registroEmpleadosBean.empleadoSelected.nombre}" style="text-transform: uppercase">
+                                                <p:ajax process="@this" />
+                                            </p:inputText>
+                                        </div>
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Primer Apellido"/>
+                                            <p:inputText id="primerAp" value="#{registroEmpleadosBean.empleadoSelected.primerAp}" style="text-transform: uppercase">
+                                                <p:ajax process="@this" />
+                                            </p:inputText>
+                                        </div>
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Segundo Apellido"/>
+                                            <p:inputText id="segundoAp" value="#{registroEmpleadosBean.empleadoSelected.segundoAp}" style="text-transform: uppercase">
+                                                <p:ajax process="@this" />
+                                            </p:inputText>
+                                        </div>
+                                    </div>
+                                    <div class="formgrid grid">
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="CURP"/>
+                                            <p:inputText id="curp" value="#{registroEmpleadosBean.empleadoSelected.curp}" maxlength="18" style="text-transform: uppercase">
+                                                <p:ajax process="@this" />
+                                            </p:inputText>  
+                                        </div>
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Fecha de nacimiento" />
+                                            <p:datePicker id="fNac" value="#{registroEmpleadosBean.empleadoSelected.fechaNacimiento}" monthNavigator="true" yearNavigator="true" yearRange="1940:2015" pattern="dd/MM/yyyy" showIcon="true" locale="es" timeZone="GMT-6">
+                                                <p:ajax process="@this" />
+                                            </p:datePicker>
+                                        </div>
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Correo"/>
+                                            <p:inputText id="correo" value="#{registroEmpleadosBean.empleadoSelected.correo}">
+                                                <p:ajax process="@this" />
+                                            </p:inputText>  
+                                        </div>
+                                    </div>
+                                    <h5>Domicilio</h5>
+                                    <div class="formgrid grid">
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Codigo Postal"/>
+                                            <p:autoComplete id="autocomplete" value="#{registroEmpleadosBean.asentamientoSelected}" completeMethod="#{registroEmpleadosBean.sugerenciasCodigoPostal}" 
+                                                            placeholder="Escribe el codigo postal..." var="sugerencia" itemLabel="#{sugerencia.cp}" itemValue="#{sugerencia}" 
+                                                            forceSelection="true"  minQueryLength="5" maxlength="5" converter="entityConverter" >
+                                                <p:ajax process="@this" event="itemSelect" listener="#{registroEmpleadosBean.domicilioEmpleado()}" update="pais estado municipio localidad asentamiento"/>
+                                                <p:column>
+                                                    <p:outputLabel value="#{sugerencia.cp}"/>
+                                                </p:column>
+                                                <p:column>
+                                                    <p:outputLabel value="#{sugerencia.descripcion}"/>
+                                                </p:column>
+                                            </p:autoComplete> 
+                                        </div>
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Pais" />
+                                            <p:inputText id="pais" value="#{registroEmpleadosBean.asentamientoSelected.key.localidad.key.municipio.key.estado.key.pais.nombrePais}" >
+                                                <p:ajax process="@this" />
+                                            </p:inputText>
+                                        </div>
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Estado" />
+                                            <p:inputText id="estado" value="#{registroEmpleadosBean.asentamientoSelected.key.localidad.key.municipio.key.estado.descripcion}" >
+                                                <p:ajax process="@this" />
+                                            </p:inputText>
+                                        </div>
+                                    </div>
+                                    <div class="formgrid grid">
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Municipio" />
+                                            <p:inputText id="municipio" value="#{registroEmpleadosBean.asentamientoSelected.key.localidad.key.municipio.descripcion}" >
+                                                <p:ajax process="@this" />
+                                            </p:inputText>
+                                        </div>
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Localidad" />
+                                            <p:inputText id="localidad" value="#{registroEmpleadosBean.asentamientoSelected.key.localidad.descripcion}" >
+                                                <p:ajax process="@this" />
+                                            </p:inputText>
+                                        </div>
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Asentamiento" />
+                                            <p:inputText id="asentamiento" value="#{registroEmpleadosBean.asentamientoSelected.descripcion}" >
+                                                <p:ajax process="@this" />
+                                            </p:inputText>
+                                        </div>
+                                    </div>
+                                    <div class="formgrid grid">
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Calle" />
+                                            <p:inputText id="calle" value="#{registroEmpleadosBean.domicilioEmpleadoSelected.calle}" >
+                                                <p:ajax process="@this" />
+                                            </p:inputText>
+                                        </div>
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Num. Ext." />
+                                            <p:inputText id="numExt" value="#{registroEmpleadosBean.domicilioEmpleadoSelected.numeroExterior}" >
+                                                <p:ajax process="@this" />
+                                            </p:inputText>
+                                        </div>
+                                        <div class="field col">
+                                            <p:outputLabel for="@next" value="Num. Int" />
+                                            <p:inputText id="numInt" value="#{registroEmpleadosBean.domicilioEmpleadoSelected.numeroInterior}" >
+                                                <p:ajax process="@this" />
+                                            </p:inputText>
+                                        </div>
+                                    </div>
+                                </p:tab>
+                                <p:tab title="Empresarial">
+                                    <div class="card">
+                                        <div class="ui-fluid formgrid grid">
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Fecha de ingreso" />
+                                                <p:datePicker id="fIngreso" value="#{registroEmpleadosBean.datoEmpresa.fechaIngreso}" monthNavigator="true" yearNavigator="true" showIcon="true" locale="es_MX" timeZone="GMT-6" pattern="dd/MM/yyyy">
+                                                    <p:ajax process="@this" />
+                                                </p:datePicker>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Fecha de baja" />
+                                                <p:datePicker value="#{registroEmpleadosBean.datoEmpresa.fechaBaja}" showIcon="true" locale="es_MX" timeZone="GMT-6" pattern="dd/MM/yyyy">
+                                                    <p:ajax process="@this" />
+                                                </p:datePicker>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="RFC" />
+                                                <p:inputText id="rfc" value="#{registroEmpleadosBean.datoEmpresa.rfc}" maxlength="18" style="text-transform: uppercase">
+                                                    <p:ajax process="@this"/>
+                                                </p:inputText>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="NSS" />
+                                                <p:inputText id="nss" value="#{registroEmpleadosBean.datoEmpresa.nss}" maxlength="15" style="text-transform: uppercase">
+                                                    <p:ajax process="@this"/>
+                                                </p:inputText>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Salario Diario" />
+                                                <p:inputNumber id="salario" value="#{registroEmpleadosBean.datoEmpresa.salarioDiario}" symbol="$ " symbolPosition="p" decimalSeparator="." decimalPlaces="2">
+                                                    <p:ajax process="@this"/>
+                                                </p:inputNumber>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Perfil" />
+                                                <p:selectOneMenu id="soPerfil" value="#{registroEmpleadosBean.datoEmpresa.perfil}" autoWidth="false" converter="entityConverter">
+                                                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
+                                                    <f:selectItems value="#{registroEmpleadosBean.lstCatPerfil}" var="perfil" itemValue="#{perfil}" itemLabel="#{perfil.descripcion}"/>
+                                                    <p:ajax process="@this"/>
+                                                </p:selectOneMenu>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Empresa" />
+                                                <p:selectOneMenu id="soEmpresa" value="#{registroEmpleadosBean.datoEmpresa.empresa}" autoWidth="false" converter="entityConverter">
+                                                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
+                                                    <f:selectItems value="#{registroEmpleadosBean.lstCatEmpresa}" var="empresa" itemValue="#{empresa}" itemLabel="#{empresa.descripcion}"/>
+                                                    <p:ajax process="@this"/>
+                                                </p:selectOneMenu>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Puesto" />
+                                                <p:selectOneMenu id="soPuesto" value="#{registroEmpleadosBean.datoEmpresa.puesto}" autoWidth="false" converter="entityConverter">
+                                                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
+                                                    <f:selectItems value="#{registroEmpleadosBean.lstCatPuesto}" var="puesto" itemValue="#{puesto}" itemLabel="#{puesto.descripcion}"/>
+                                                    <p:ajax process="@this"/>
+                                                </p:selectOneMenu>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Área" />
+                                                <p:selectOneMenu id="soArea" value="#{registroEmpleadosBean.datoEmpresa.area}" autoWidth="false" converter="entityConverter">
+                                                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
+                                                    <f:selectItems value="#{registroEmpleadosBean.lstCatArea}" var="area" itemValue="#{area}" itemLabel="#{area.descripcion}"/>
+                                                    <p:ajax process="@this"/>
+                                                </p:selectOneMenu>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Ubicación" />
+                                                <p:selectOneMenu id="soUbica" value="#{registroEmpleadosBean.datoEmpresa.planta}" autoWidth="false" converter="entityConverter">
+                                                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
+                                                    <f:selectItems value="#{registroEmpleadosBean.lstCatPlanta}" var="planta" itemValue="#{planta}" itemLabel="#{planta.descripcion}"/>
+                                                    <p:ajax process="@this"/>
+                                                </p:selectOneMenu>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Tipo de contrato" />
+                                                <p:selectOneMenu id="soTipoContrato" value="#{registroEmpleadosBean.datoEmpresa.tipoContrato}" autoWidth="false" converter="entityConverter">
+                                                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true" />
+                                                    <f:selectItems value="#{registroEmpleadosBean.tiposContrato}" var="tipoContrato" itemValue="#{tipoContrato}" itemLabel="#{tipoContrato.clave} - #{tipoContrato.nombre}" />
+                                                    <p:ajax process="@this" />
+                                                </p:selectOneMenu>
+                                            </div>
+
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Tipo de jornada" />
+                                                <p:selectOneMenu id="soTipoJornada" value="#{registroEmpleadosBean.datoEmpresa.tipoJornada}" autoWidth="false" converter="entityConverter">
+                                                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
+                                                    <f:selectItems value="#{registroEmpleadosBean.tiposJornada}" var="tipoJornada" itemValue="#{tipoJornada}" itemLabel="#{tipoJornada.clave} - #{tipoJornada.nombre}"></f:selectItems>
+                                                    <p:ajax process="@this" />
+                                                </p:selectOneMenu>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Tipo de régimen"/>
+                                                <p:selectOneMenu id="soTipoRegimen" value="#{registroEmpleadosBean.datoEmpresa.tipoRegimen}" autoWidth="false" converter="entityConverter">
+                                                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true" />
+                                                    <f:selectItems value="#{registroEmpleadosBean.tiposRegimen}" var="tipoRegimen" itemValue="#{tipoRegimen}" itemLabel="#{tipoRegimen.clave} - #{tipoRegimen.nombre}"></f:selectItems>
+                                                    <p:ajax process="@this" />
+                                                </p:selectOneMenu>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Hora de entrada" />
+                                                <p:datePicker value="#{registroEmpleadosBean.datoEmpresa.horaEntrada}" timeOnly="true" timeZone="GMT-6" locale="es">
+                                                    <p:ajax process="@this" />
+                                                </p:datePicker>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Tolerancia (minutos)"></p:outputLabel>
+                                                <p:inputNumber value="#{registroEmpleadosBean.datoEmpresa.minutosTolerancia}">
+                                                    <p:ajax process="@this" />
+                                                </p:inputNumber>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Código Postal"/>
+                                                <p:inputText value="#{registroEmpleadosBean.datoEmpresa.codigoPostal}" maxlength="5">
+                                                    <p:ajax process="@this" />
+                                                </p:inputText>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Entidad Federativa" />
+                                                <p:selectOneMenu id="soEntidadFederativa" value="#{registroEmpleadosBean.datoEmpresa.entidadFederativa}" autoWidth="false" converter="entityConverter">
+                                                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
+                                                    <f:selectItems value="#{registroEmpleadosBean.entidadesFederativas}" var="entidad" itemLabel="#{entidad.clave} - #{entidad.nombre}" itemValue="#{entidad}"/>
+                                                    <p:ajax process="@this" />
+                                                </p:selectOneMenu>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Riesgo puesto" />
+                                                <p:selectOneMenu id="soRiesgoPuesto" value="#{registroEmpleadosBean.datoEmpresa.riesgoPuesto}" autoWidth="false" converter="entityConverter">
+                                                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
+                                                    <f:selectItems value="#{registroEmpleadosBean.riesgosPuesto}" var="riesgo" itemLabel="#{riesgo.clave} - #{riesgo.descripcion}"/>
+                                                    <p:ajax process="@this" />
+                                                </p:selectOneMenu>
+                                            </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Periodicidad de pago" />
+                                                <p:selectOneMenu id="soPeriodicidadPago" value="#{registroEmpleadosBean.datoEmpresa.periodicidadPago}" autoWidth="false" converter="entityConverter">
+                                                    <f:selectItem itemLabel="--Seleccione--" noSelectionOption="true"/>
+                                                    <f:selectItems value="#{registroEmpleadosBean.periodicidadesPago}" var="periodicidad" itemLabel="#{periodicidad.periodicidad} - #{periodicidad.descripcion}" itemValue="#{periodicidad}"/>
+                                                    <p:ajax process="@this" />
+                                                </p:selectOneMenu>
+                                            </div>
+                                            <div class="field col-12 md:col-1">
+                                                <p:outputLabel for="@next" value="Sindicalizado"/>
+                                                <p:selectBooleanButton value="#{registroEmpleadosBean.datoEmpresa.sindicalizado}" onLabel="Si" offLabel="No" onIcon="pi pi-check" offIcon="pi pi-times" style="width:6rem" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </p:tab>
+                                <p:tab title="Biométrica">
+                                    <div align="center">
+                                        <p:panelGrid columns="2">
+                                            <p:card>
+                                                <div class="field column">
+                                                    <p:panelGrid columns="2">
+                                                        <p:outputPanel id="previewFingerprint1">
+                                                            <p:graphicImage rendered="#{empty registroEmpleadosBean.detBiometrico.huella}" name="images/huella/finger_print_01.png" library="recursos" style="max-height: 14rem;"/>
+                                                            <p:graphicImage rendered="#{not empty registroEmpleadosBean.detBiometrico.huella}" name="images/huella/finger_print_02.png" library="recursos" style="max-height: 14rem;"/>
+                                                        </p:outputPanel>
+                                                        <p:outputPanel id="previewFingerprint2">
+                                                            <p:graphicImage rendered="#{registroEmpleadosBean.detBiometrico eq null}" name="images/huella/finger_print_01.png" library="recursos" style="max-height: 14rem;"/>
+                                                            <p:graphicImage rendered="#{registroEmpleadosBean.detBiometrico.huella2 ne null}" name="images/huella/finger_print_02.png" library="recursos" style="max-height: 14rem;"/>
+                                                        </p:outputPanel>
+                                                    </p:panelGrid>
+                                                    <p:commandButton value="Capturar biométricos" icon="pi pi-sync" process="@this" actionListener="#{registroEmpleadosBean.consultaBiometrico()}" immediate="true"/>
+                                                </div>
+                                            </p:card>
+                                            <p:card>
+                                                <div class="card">
+                                                    <p:outputPanel id="previewFotografia">
+                                                        <p:graphicImage rendered="#{empty registroEmpleadosBean.empleadoFoto.fotografia}" library="recursos" name="images/user-icon.png" style="height: 15rem;" />
+                                                        <img src="#{registroEmpleadosBean.empleadoFoto.fotografia}" style="height: 15rem;"/>
+                                                    </p:outputPanel>
+                                                    <p:commandButton value="Tomar fotografía" icon="pi pi-camera" process="@this" immediate="true" update="formRegistroEmpleado:photo" oncomplete="PF('dialogFotografia').show();" />
+                                                </div>
+                                            </p:card>
+                                        </p:panelGrid>
+                                    </div>
+                                </p:tab>
+                                <p:tab title="Percepciones">
+                                    <div class="ui-fluid formgrid grid">
+                                        <div class="field col-12 md:col-3">
+                                            <p:selectOneMenu id="selTipoPercepcion" value="#{registroEmpleadosBean.percepcionEmpleado.tipoPercepcion}" autoWidth="false" converter="entityConverter" filter="true" filterMatchMode="contains">
+                                                <f:selectItem itemLabel="---SELECCIONE UNA PERCEPCION---"/>
+                                                <f:selectItems value="#{registroEmpleadosBean.tiposPercepcion}" var="tipoPercepcion" itemLabel="#{tipoPercepcion.clave} - #{tipoPercepcion.descripcion}" itemValue="#{tipoPercepcion}"/>
+                                            </p:selectOneMenu>
+                                        </div>
+                                        <div class="field col-12 md:col-3">
+                                            <p:inputNumber id="txtImportePercepcion" value="#{registroEmpleadosBean.percepcionEmpleado.importeMaximo}" symbol="$ " decimalPlaces="2" decimalSeparator="." thousandSeparator="," placeholder="Importe máximo">
+                                                <p:ajax process="@this" />
+                                            </p:inputNumber>
+                                        </div>
+                                        <div class="field col-12 md:col-3">
+                                            <p:selectBooleanButton id="selPercepcionActivo" value="#{registroEmpleadosBean.percepcionEmpleado.activo}" onLabel="Activo" offLabel="Inactivo" onIcon="pi pi-check" offIcon="pi pi-times" style="width:6rem" disabled="false" />
+                                        </div>
+                                        <div class="field col-12 md:col-3">
+                                            <p:commandButton value="Agregar" actionListener="#{registroEmpleadosBean.agregarPercepcionEmpleado}" icon="pi pi-plus" update="dt-percepcion-empleado selTipoPercepcion txtImportePercepcion selPercepcionActivo"></p:commandButton>
+                                        </div>
+                                    </div>
+                                    <p:dataTable id="dt-percepcion-empleado" value="#{registroEmpleadosBean.percepcionesEmpleado}" var="percepcion" paginator="true" rows="5" paginatorPosition="bottom" lazy="true">
+                                        <p:column headerText="Percepcion">
+                                            <p:outputLabel value="#{percepcion.tipoPercepcion.clave} - #{percepcion.tipoPercepcion.descripcion}" />
+                                        </p:column>
+                                        <p:column headerText="Importe máximo" width="6rem">
+                                            <p:inputNumber value="#{percepcion.importeMaximo}" symbol="$ " decimalPlaces="2" decimalSeparator="." thousandSeparator=",">
+                                                <p:ajax process="@this" />
+                                            </p:inputNumber>
+                                        </p:column>
+                                        <p:column headerText="Activo" width="4rem">
+                                            <p:selectBooleanButton value="#{percepcion.activo}" onLabel="Si" offLabel="No" onIcon="pi pi-check" offIcon="pi pi-times" style="width:6rem"/>
+                                        </p:column>
+                                        <p:column width="2rem">
+                                            <p:commandButton icon="pi pi-trash" onclick="PF('dlgEliminarPercepcionEmpleado').show();" styleClass="ui-button-danger">
+                                                <f:setPropertyActionListener value="#{percepcion}" target="#{registroEmpleadosBean.percepcionEmpleado}"></f:setPropertyActionListener>
+                                            </p:commandButton>
+                                        </p:column>
+                                    </p:dataTable>
+                                </p:tab>
+                                <p:tab title="Préstamos">
+                                    <p:toolbar>
+                                        <p:toolbarGroup>
+                                            <p:commandButton value="Agregar" icon="pi pi-plus" oncomplete="PF('dgPrestamo').show();"></p:commandButton>
+                                        </p:toolbarGroup>
+                                    </p:toolbar>
+                                    <p:dataTable id="dt-prestamos" widgetVar="dtPrestamos" value="#{registroEmpleadosBean.empleadoSelected.prestamos}" var="prestamo" allowUnsorting="true" sortMode="single" reflow="true" lazy="true">
+                                        <p:column headerText="Fecha inicio" sortBy="#{prestamo.fechaInicio}">
+                                            <p:datePicker value="#{prestamo.fechaInicio}" monthNavigator="true" yearNavigator="true" showIcon="true" pattern="dd/MM/yyyy" locale="es" timeZone="GMT-6">
+                                                <p:ajax process="@this"></p:ajax>
+                                            </p:datePicker>
+                                        </p:column>
+                                        <p:column headerText="Fecha fin" sortBy="#{prestamo.fechaFin}">
+                                            <p:datePicker value="#{prestamo.fechaFin}" monthNavigator="true" yearNavigator="true" showIcon="true" pattern="dd/MM/yyyy" locale="es" timeZone="GMT-6">
+                                                <p:ajax process="@this"></p:ajax>
+                                            </p:datePicker>
+                                        </p:column>
+                                        <p:column headerText="Periodicidad de pago" width="auto">
+                                            <p:selectOneMenu value="#{prestamo.periodicidadPago}" converter="entityConverter" autoWidth="false">
+                                                <f:selectItem itemLabel="Seleccione la periodicidad de pago" noSelectionOption="true" />
+                                                <f:selectItems value="#{registroEmpleadosBean.periodicidadesPago}" var="periodicidad" itemLabel="#{periodicidad.descripcion}"></f:selectItems>
+                                            </p:selectOneMenu>
+                                        </p:column>
+                                        <p:column headerText="Tipo Préstamo">
+                                            <p:selectOneMenu value="#{prestamo.tipoPrestamo}" converter="entityConverter" autoWidth="false">
+                                                <f:selectItem itemLabel="Seleccione un tipo de préstamo" noSelectionOption="true" />
+                                                <f:selectItems value="#{registroEmpleadosBean.tiposPrestamo}" var="tipoPrestamo" itemLabel="#{tipoPrestamo.descripcion}" itemValue="#{tipoPrestamo}" />
+                                            </p:selectOneMenu>
+                                        </p:column>
+                                        <p:column headerText="Acumulado" width="5rem">
+                                            <p:inputNumber value="#{prestamo.acumulado}" decimalSeparator="2" symbol="$" symbolPosition="p" emptyValue="empty" />
+                                        </p:column>
+                                        <p:column headerText="Importe" width="5rem;">
+                                            <p:inputNumber value="#{prestamo.importe}" decimalSeparator="2" symbol="$" symbolPosition="p" emptyValue="empty" />
+                                        </p:column>
+                                        <p:column headerText="Total" width="5rem">
+                                            <p:inputNumber value="#{prestamo.total}" decimalSeparator="2" symbol="$" symbolPosition="p" emptyValue="empty" />
+                                        </p:column>
+                                        <p:column width="3rem;">
+                                            <p:commandButton icon="pi pi-trash" styleClass="ui-button-danger" oncomplete="PF('dlgEliminarPrestamo').show();">
+                                                <f:setPropertyActionListener value="#{prestamo}" target="#{registroEmpleadosBean.prestamo}"></f:setPropertyActionListener>
+                                            </p:commandButton>
+                                        </p:column>
+                                    </p:dataTable>
+                                </p:tab>
+                            </p:tabView>
+
                             <f:facet name="footer">
                                 <p:commandButton value="Guardar" icon="pi pi-save" actionListener="#{registroEmpleadosBean.guardarEmpleado()}" process="panelDialogEmpleado @this" onclick="PF('statusInfoDialog').show();" oncomplete="PF('statusInfoDialog').hide();"/>
                                 <p:commandButton value="Cerrar" icon="pi pi-times" onclick="PF('dialogEmpleado').hide()" class="ui-button-secondary" resetValues="true"/>
@@ -453,7 +479,7 @@
                                 <h:panelGrid columns="3" cellpadding="5">
                                     <p:photoCam id="foto" widgetVar="pc" listener="#{registroEmpleadosBean.oncapture}"/>
                                     <p:outputPanel id="photo">
-                                    	<p:graphicImage rendered="#{not empty registroEmpleadosBean.empleadoFoto.fotografia}" library="recursos" name="images/user-icon.png" style="max-width: 100px;"></p:graphicImage>
+                                        <p:graphicImage rendered="#{not empty registroEmpleadosBean.empleadoFoto.fotografia}" library="recursos" name="images/user-icon.png" style="max-width: 100px;"></p:graphicImage>
                                         <img src="#{registroEmpleadosBean.empleadoFoto.fotografia}"/>
                                     </p:outputPanel>
                                 </h:panelGrid>
@@ -467,7 +493,7 @@
                             </f:facet>
                         </p:dialog> 
 
-                         <p:dialog id="dialogBiometrico" header="Biométrico" widgetVar="dialogBiometrico" modal="true" draggable="false" cache="false" dynamic="true" closable="false">
+                        <p:dialog id="dialogBiometrico" header="Biométrico" widgetVar="dialogBiometrico" modal="true" draggable="false" cache="false" dynamic="true" closable="false">
                             <p:outputPanel id="panelDialogBiometrico" class="ui-fluid">
                                 <h:panelGrid columns="2" cellpadding="5" columnClasses="ui-g-6, ui-g-6">
                                     <p:commandLink oncomplete="InvokeFingerScan('Enrollment'); PF('bui').show()" actionListener="#{registroEmpleadosBean.setNumBiometrico(1)}">
@@ -492,81 +518,81 @@
                             </f:facet>
                         </p:dialog> 
                         <p:dialog id="dg-prestamo" widgetVar="dgPrestamo" header="Préstamo" showEffect="hide" modal="true" responsive="true">
-							<div class="ui-fluid">
-	                        	<div class="p-field">
-									<p:outputLabel value="Tipo de préstamo"></p:outputLabel>
-									<p:selectOneMenu id="tipoPrestamo" value="#{registroEmpleadosBean.prestamo.tipoPrestamo}" converter="entityConverter">
-										<f:selectItem itemLabel="Seleccione un tipo de préstamo" noSelectionOption="true" />
-										<f:selectItems value="#{registroEmpleadosBean.tiposPrestamo}" var="tipoPrestamo" itemLabel="#{tipoPrestamo.descripcion}" itemValue="#{tipoPrestamo}">
-										</f:selectItems>
-										<p:ajax process="@this"></p:ajax>
-									</p:selectOneMenu>
-								</div>
-								<div class="p-field">
-									<p:outputLabel value="Fecha inicio"></p:outputLabel>
-									<p:datePicker value="#{registroEmpleadosBean.prestamo.fechaInicio}" showIcon="true" yearNavigator="true" monthNavigator="true" weekCalculator="true" pattern="dd/MM/yyyy" timeZone="GMT-6" locale="es_MX">
-										<p:ajax process="@this"></p:ajax>
-									</p:datePicker>
-								</div>
-								<div class="p-field">
-									<p:outputLabel value="Fecha Fin"></p:outputLabel>
-									<p:datePicker value="#{registroEmpleadosBean.prestamo.fechaFin}" showIcon="true" yearNavigator="true" monthNavigator="true" weekCalculator="true" pattern="dd/MM/yyyy" timeZone="GMT-6" locale="es_MX">
-										<p:ajax process="@this"></p:ajax>
-									</p:datePicker>
-								</div>
-								<div class="p-field">
-									<p:outputLabel value="Acumulado"></p:outputLabel>
-									<p:inputNumber value="#{registroEmpleadosBean.prestamo.acumulado}" symbol="$ " decimalPlaces="2" decimalSeparator="." thousandSeparator="," minValue="0.00" emptyValue="zero">
-										<p:ajax process="@this"></p:ajax>
-									</p:inputNumber>
-								</div>
-								<div class="p-field">
-									<p:outputLabel value="Importe"></p:outputLabel>
-									<p:inputNumber value="#{registroEmpleadosBean.prestamo.importe}" symbol="$ " decimalPlaces="2" decimalSeparator="." thousandSeparator="," minValue="0.00" emptyValue="zero">
-										<p:ajax process="@this"></p:ajax>
-									</p:inputNumber>
-								</div>
-								<div class="p-field">
-									<p:outputLabel value="Periodicidad de pago"></p:outputLabel>
-									<p:selectOneMenu value="#{registroEmpleadosBean.prestamo.periodicidadPago}" converter="entityConverter">
-										<f:selectItem itemLabel="Seleccione la periodicidad de pago" noSelectionOption="true" />
-										<f:selectItems value="#{registroEmpleadosBean.periodicidadesPago}" var="periodicidad" itemLabel="#{periodicidad.descripcion}">
-										</f:selectItems>
-										<p:ajax process="@this"></p:ajax>
-									</p:selectOneMenu>
-								</div>
-								<div class="p-field">
-									<p:outputLabel value="Total"></p:outputLabel>
-									<p:inputNumber value="#{registroEmpleadosBean.prestamo.total}" symbol="$ " decimalPlaces="2" decimalSeparator="." thousandSeparator="," minValue="0.00" emptyValue="zero">
-										<p:ajax process="@this"></p:ajax>
-									</p:inputNumber>
-								</div>
-							</div>
-							<f:facet name="footer">
-								<p:commandButton value="Agregar" process="@this" actionListener="#{registroEmpleadosBean.agregarPrestamo()}">
-									<p:confirm header="Confirmación" message="¿Está seguro que desea agregar el préstamo?" icon="pi pi-exclamation-triangle"/>
-								</p:commandButton>
-							</f:facet>
+                            <div class="ui-fluid">
+                                <div class="p-field">
+                                    <p:outputLabel value="Tipo de préstamo"></p:outputLabel>
+                                    <p:selectOneMenu id="tipoPrestamo" value="#{registroEmpleadosBean.prestamo.tipoPrestamo}" converter="entityConverter">
+                                        <f:selectItem itemLabel="Seleccione un tipo de préstamo" noSelectionOption="true" />
+                                        <f:selectItems value="#{registroEmpleadosBean.tiposPrestamo}" var="tipoPrestamo" itemLabel="#{tipoPrestamo.descripcion}" itemValue="#{tipoPrestamo}">
+                                        </f:selectItems>
+                                        <p:ajax process="@this"></p:ajax>
+                                    </p:selectOneMenu>
+                                </div>
+                                <div class="p-field">
+                                    <p:outputLabel value="Fecha inicio"></p:outputLabel>
+                                    <p:datePicker value="#{registroEmpleadosBean.prestamo.fechaInicio}" showIcon="true" yearNavigator="true" monthNavigator="true" weekCalculator="true" pattern="dd/MM/yyyy" timeZone="GMT-6" locale="es_MX">
+                                        <p:ajax process="@this"></p:ajax>
+                                    </p:datePicker>
+                                </div>
+                                <div class="p-field">
+                                    <p:outputLabel value="Fecha Fin"></p:outputLabel>
+                                    <p:datePicker value="#{registroEmpleadosBean.prestamo.fechaFin}" showIcon="true" yearNavigator="true" monthNavigator="true" weekCalculator="true" pattern="dd/MM/yyyy" timeZone="GMT-6" locale="es_MX">
+                                        <p:ajax process="@this"></p:ajax>
+                                    </p:datePicker>
+                                </div>
+                                <div class="p-field">
+                                    <p:outputLabel value="Acumulado"></p:outputLabel>
+                                    <p:inputNumber value="#{registroEmpleadosBean.prestamo.acumulado}" symbol="$ " decimalPlaces="2" decimalSeparator="." thousandSeparator="," minValue="0.00" emptyValue="zero">
+                                        <p:ajax process="@this"></p:ajax>
+                                    </p:inputNumber>
+                                </div>
+                                <div class="p-field">
+                                    <p:outputLabel value="Importe"></p:outputLabel>
+                                    <p:inputNumber value="#{registroEmpleadosBean.prestamo.importe}" symbol="$ " decimalPlaces="2" decimalSeparator="." thousandSeparator="," minValue="0.00" emptyValue="zero">
+                                        <p:ajax process="@this"></p:ajax>
+                                    </p:inputNumber>
+                                </div>
+                                <div class="p-field">
+                                    <p:outputLabel value="Periodicidad de pago"></p:outputLabel>
+                                    <p:selectOneMenu value="#{registroEmpleadosBean.prestamo.periodicidadPago}" converter="entityConverter">
+                                        <f:selectItem itemLabel="Seleccione la periodicidad de pago" noSelectionOption="true" />
+                                        <f:selectItems value="#{registroEmpleadosBean.periodicidadesPago}" var="periodicidad" itemLabel="#{periodicidad.descripcion}">
+                                        </f:selectItems>
+                                        <p:ajax process="@this"></p:ajax>
+                                    </p:selectOneMenu>
+                                </div>
+                                <div class="p-field">
+                                    <p:outputLabel value="Total"></p:outputLabel>
+                                    <p:inputNumber value="#{registroEmpleadosBean.prestamo.total}" symbol="$ " decimalPlaces="2" decimalSeparator="." thousandSeparator="," minValue="0.00" emptyValue="zero">
+                                        <p:ajax process="@this"></p:ajax>
+                                    </p:inputNumber>
+                                </div>
+                            </div>
+                            <f:facet name="footer">
+                                <p:commandButton value="Agregar" process="@this" actionListener="#{registroEmpleadosBean.agregarPrestamo()}">
+                                    <p:confirm header="Confirmación" message="¿Está seguro que desea agregar el préstamo?" icon="pi pi-exclamation-triangle"/>
+                                </p:commandButton>
+                            </f:facet>
                         </p:dialog>
-                        
-                        
+
+
                         <p:confirmDialog widgetVar="dlgEliminarPrestamo" showEffect="fade" width="30rem" message="¿Está seguro que desea eliminar el préstamo seleccionado?" header="Confirmar" severity="warn">
                             <p:commandButton value="Sí" icon="pi pi-check" actionListener="#{registroEmpleadosBean.eliminarPrestamo(prestamo)}" process="@this" oncomplete="PF('dlgEliminarPrestamo').hide();"/>
                             <p:commandButton value="No" type="button" styleClass="ui-button-secondary" icon="pi pi-times" onclick="PF('dlgEliminarPrestamo').hide()" />
                         </p:confirmDialog>
-                        
+
                         <p:confirmDialog widgetVar="dlgEliminarPercepcionEmpleado" showEffect="fade" width="30rem" message="¿Está seguro que desea eliminar la percepción seleccionada?" header="Confirmar" severity="warn">
                             <p:commandButton value="Sí" icon="pi pi-check" actionListener="#{registroEmpleadosBean.eliminarPercepcionEmpleado}" process="@this" oncomplete="PF('dlgEliminarPercepcionEmpleado').hide();"/>
                             <p:commandButton value="No" type="button" styleClass="ui-button-secondary" icon="pi pi-times" onclick="PF('dlgEliminarPercepcionEmpleado').hide()" />
                         </p:confirmDialog>
-                        
+
                         <p:confirmDialog widgetVar="dialogEliminarEmpleado" showEffect="fade" width="300" message="¿Está seguro que desea dar de baja al empleado?" header="Confirmar" severity="warn">
-                        	<div>
-	                            <p:commandButton value="Sí" icon="pi pi-check" actionListener="#{registroEmpleadosBean.eliminaEmpleado()}" process="@this" oncomplete="PF('dialogEliminarEmpleado').hide()"/>
-	                            <p:commandButton value="No" type="button" styleClass="ui-button-secondary" icon="pi pi-times" onclick="PF('dialogEliminarEmpleado').hide()" />
-                        	</div>
+                            <div>
+                                <p:commandButton value="Sí" icon="pi pi-check" actionListener="#{registroEmpleadosBean.eliminaEmpleado()}" process="@this" oncomplete="PF('dialogEliminarEmpleado').hide()"/>
+                                <p:commandButton value="No" type="button" styleClass="ui-button-secondary" icon="pi pi-times" onclick="PF('dialogEliminarEmpleado').hide()" />
+                            </div>
                         </p:confirmDialog>
-                        
+
                         <p:confirmDialog global="true" showEffect="fade" hideEffect="fade" responsive="true" width="300">
                             <p:commandButton value="Sí" type="button" styleClass="ui-confirmdialog-yes" icon="pi pi-check" />
                             <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no ui-button-secondary" icon="pi pi-times" />
@@ -579,7 +605,7 @@
                 $(".clean").click(function () {
                     $('.respresultado').hide();
                 });
-               
+
                 function createCORSRequest(method, url) {
                     var xhr = new XMLHttpRequest();
                     if ("withCredentials" in xhr) {
@@ -600,7 +626,7 @@
                         throw new Error('CORS not supported');
                     }
                     request.setRequestHeader("Content-Type", "application/json");
-                    
+
                     request.onreadystatechange = function () {
                         if (this.readyState == 4) {
                             if (this.status == 200) {
@@ -633,7 +659,7 @@
                     request.ontimeout = function () {
                         console.error("La solicitud de adquisición de datos ha expirado.");
                     };
-                                        
+
                     var obj = new Object();
                     obj.tpAccion = TpAccion;
                     var jsonString = JSON.stringify(obj);

--- a/src/main/webapp/protected/registroEmpleado.xhtml
+++ b/src/main/webapp/protected/registroEmpleado.xhtml
@@ -40,15 +40,15 @@
                                 </p:selectOneMenu>
                             </p:toolbarGroup>
                             <p:toolbarGroup>
-                                <p:outputLabel value="Activo "/>
+                                <p:outputLabel id="toggleactivo" value="Activo "/>
                                 <p:toggleSwitch value="#{registroEmpleadosBean.activo}">
-                                    <p:ajax  update="dtEmpleados"/>
+                                    <p:ajax  update="dtEmpleados, toggleinactivo"/>
                                 </p:toggleSwitch>
                             </p:toolbarGroup>
                             <p:toolbarGroup>
                                 <p:outputLabel value="Inactivo "/>
-                                <p:toggleSwitch value="#{registroEmpleadosBean.inactivo}">
-                                    <p:ajax  update="dtEmpleados"/>
+                                <p:toggleSwitch id="toggleinactivo" value="#{registroEmpleadosBean.inactivo}">
+                                    <p:ajax  update="dtEmpleados, toggleactivo"/>
                                 </p:toggleSwitch>
                             </p:toolbarGroup>
                             <p:toolbarGroup align="right">

--- a/src/main/webapp/protected/registroEmpleado.xhtml
+++ b/src/main/webapp/protected/registroEmpleado.xhtml
@@ -42,13 +42,13 @@
                             <p:toolbarGroup>
                                 <p:outputLabel id="toggleactivo" value="Activo "/>
                                 <p:toggleSwitch value="#{registroEmpleadosBean.activo}">
-                                    <p:ajax  update="dtEmpleados, toggleinactivo"/>
+                                    <p:ajax  update="dtEmpleados" process="@this"/>
                                 </p:toggleSwitch>
                             </p:toolbarGroup>
                             <p:toolbarGroup>
                                 <p:outputLabel value="Inactivo "/>
                                 <p:toggleSwitch id="toggleinactivo" value="#{registroEmpleadosBean.inactivo}">
-                                    <p:ajax  update="dtEmpleados, toggleactivo"/>
+                                    <p:ajax  update="dtEmpleados" process="@this"/>
                                 </p:toggleSwitch>
                             </p:toolbarGroup>
                             <p:toolbarGroup align="right">
@@ -62,16 +62,25 @@
                                      selection="#{registroEmpleadosBean.lstEmpleadosSelected}" rowKey="#{empleado.idEmpleado}" paginator="true" rows="10" rowSelectMode="add" 
                                      paginatorPosition="bottom" lazy="true">
 
-                            <p:column headerText="Número" sortBy="#{empleado.numEmpleado}" filterBy="#{empleado.numEmpleado}" width="4rem">
+                            <f:facet name="header">
+                                <div class="flex justify-content-start">
+                                    <p:inputText id="filtarNombre" value="#{registroEmpleadosBean.texto}" onkeyup="PF('dtEmpleados').filter()" style="width:300px"
+                                                 placeholder="Buscar empleado por nombre o apellidos">
+                                        <p:ajax update="dtEmpleados" process="@this"/>
+                                        </p:inputText>
+                                </div>
+                            </f:facet>
+
+                            <p:column headerText="Número" sortBy="#{empleado.numEmpleado}" filterable="false" width="4rem">
                                 <h:outputText value="#{empleado.numEmpleado}" styleClass="customer-badge status-#{empleado.activo eq 1 ? 'qualified': 'unqualified'}"/>
                             </p:column>
-                            <p:column headerText="Primer Apellido" sortBy="#{empleado.primerAp}" filterBy="#{empleado.primerAp}">
+                            <p:column headerText="Primer Apellido" sortBy="#{empleado.primerAp}" filterable="false">
                                 <h:outputText style="vertical-alin: middle; margin-left: .5rem" value="#{empleado.primerAp}" />
                             </p:column>
-                            <p:column headerText="Segundo Apellido" sortBy="#{empleado.segundoAp}" filterBy="#{empleado.segundoAp}">
+                            <p:column headerText="Segundo Apellido" sortBy="#{empleado.segundoAp}" filterable="false">
                                 <h:outputText style="vertical-alin: middle; margin-left: .5rem" value="#{empleado.segundoAp}" />
                             </p:column>
-                            <p:column headerText="Nombre" sortBy="#{empleado.nombre}" filterBy="#{empleado.nombre}">
+                            <p:column headerText="Nombre" sortBy="#{empleado.nombre}" filterable="false">
                                 <h:outputText style="vertical-align: middle; margin-left: .5rem" value="#{empleado.nombre}" />
                             </p:column>
                             <p:column width="6rem">


### PR DESCRIPTION
Agregar en la pantalla de registro de empleados una opción que filtre por la empresa a la que pertenece el empleado o la planta en la que se encuentra trabajando el empleado, también se considera otras maneras para filtrar a los empleados, dependiendo de si se encuentran activos o inactivos dentro de la empresa. Por último también agregar la opción que va buscando a los empleados por nombre o alguno de sus apellidos. Esto con la finalidad de que la pantalla sea más amigable con el usuario y presente la información de una manera más ordenada.