### PR TITLE
Corregir bug de empleados que ya no laboran en la empresa

### DIFF
--- a/src/main/java/mx/com/ferbo/controller/sistema/SalarioMinimoBean.java
+++ b/src/main/java/mx/com/ferbo/controller/sistema/SalarioMinimoBean.java
@@ -21,6 +21,7 @@ import mx.com.ferbo.dao.SalarioMinimoDAO;
 import mx.com.ferbo.dao.n.EmpleadoDAO;
 import mx.com.ferbo.dto.SalarioMinimoDTO;
 import mx.com.ferbo.model.DetEmpleado;
+import mx.com.ferbo.util.DateUtil;
 import mx.com.ferbo.util.SGPException;
 
 @Named(value = "salarioMinBean")
@@ -214,12 +215,12 @@ public class SalarioMinimoBean implements Serializable {
             }
 
             if (this.salarioGeneral == true && this.salarioFrontera == false) {
-                this.lstEmpleadosPorActualizar = empleadoDAO.empleadosSalarioMinimoGeneral(this.salario.getZonaG());
+                this.lstEmpleadosPorActualizar = empleadoDAO.empleadosSalarioMinimoGeneral(this.salario.getZonaG(), DateUtil.now());
                 this.salarioSugerido = this.salario.getZonaG();
             }
 
             if (this.salarioFrontera == true && this.salarioGeneral == false) {
-                this.lstEmpleadosPorActualizar = empleadoDAO.empleadosSalarioMinimoFrontera(this.salario.getZonaLFN());
+                this.lstEmpleadosPorActualizar = empleadoDAO.empleadosSalarioMinimoFrontera(this.salario.getZonaLFN(), DateUtil.now());
                 this.salarioSugerido = this.salario.getZonaLFN();
             }
 

--- a/src/main/java/mx/com/ferbo/dao/n/EmpleadoDAO.java
+++ b/src/main/java/mx/com/ferbo/dao/n/EmpleadoDAO.java
@@ -172,15 +172,16 @@ public class EmpleadoDAO extends BaseDAO<DetEmpleado, Integer> {
         return foto;
     }
 
-    public synchronized List<DetEmpleado> empleadosSalarioMinimoGeneral(BigDecimal salarioMinimo) throws SGPException{
+    public synchronized List<DetEmpleado> empleadosSalarioMinimoGeneral(BigDecimal salarioMinimo, Date hoy) throws SGPException{
         List<DetEmpleado> empleados = null;
         EntityManager em = null;
         
         try{
             log.info("Inicio el proceso de obtener los empleados por debajo del salario minimo de ZG");
             em = getEntityManager();
-            TypedQuery resultado = em.createQuery("select e from DetEmpleado e where e.datoEmpresa.salarioDiario < :salarioMinimo", DetEmpleado.class);
+            TypedQuery resultado = em.createQuery("select e from DetEmpleado e where e.datoEmpresa.salarioDiario < :salarioMinimo and (e.datoEmpresa.fechaBaja is null or e.datoEmpresa.fechaBaja > :hoy)", DetEmpleado.class);
             resultado.setParameter("salarioMinimo", salarioMinimo);
+            resultado.setParameter("hoy", hoy);
             empleados = resultado.getResultList();
             log.info("Finaliza el proceso de obtener los empleados por debajo del salario minimo de ZG");
         }
@@ -196,15 +197,16 @@ public class EmpleadoDAO extends BaseDAO<DetEmpleado, Integer> {
         return empleados;
     }
     
-    public synchronized List<DetEmpleado> empleadosSalarioMinimoFrontera(BigDecimal salarioMinimo) throws SGPException{
+    public synchronized List<DetEmpleado> empleadosSalarioMinimoFrontera(BigDecimal salarioMinimo, Date hoy) throws SGPException{
         List<DetEmpleado> empleados = null;
         EntityManager em = null;
         
         try{
             log.info("Inicio el proceso de obtener los empleados por debajo del salario minimo de ZF");
             em = getEntityManager();
-            TypedQuery resultado = em.createQuery("select e from DetEmpleado e where e.datoEmpresa.salarioDiario < :salarioMinimo", DetEmpleado.class);
+            TypedQuery resultado = em.createQuery("select e from DetEmpleado e where e.datoEmpresa.salarioDiario < :salarioMinimo and (e.datoEmpresa.fechaBaja is null or e.datoEmpresa.fechaBaja > :hoy)", DetEmpleado.class);
             resultado.setParameter("salarioMinimo", salarioMinimo);
+            resultado.setParameter("hoy", hoy);
             empleados = resultado.getResultList();
             log.info("Finaliza el proceso de obtener los empleados por debajo del salario minimo de ZF");
         }


### PR DESCRIPTION
Al momento de mostrar la lista de empleados para modificar su salario, ya no se muestran los empleados que ya no dan su servicio a la empresa antes de la fecha diaria.