### PR TITLE
Corregir inicializacion lenta en el periodo de vacaciones

### DIFF
--- a/src/main/java/mx/com/ferbo/controller/AsistenciaBean.java
+++ b/src/main/java/mx/com/ferbo/controller/AsistenciaBean.java
@@ -493,7 +493,7 @@ public class AsistenciaBean implements Serializable {
                 throw new SGPException("Error: No tiene dias laborales asignados. Por favor contactar a RH");
             }
             inicializaSolicitud();
-            PrimeFaces.current().executeScript("PF('dialogVacacionesView').show()");
+            PrimeFaces.current().executeScript("PF('dialogVacaciones').show()");
         } catch (SGPException sgpEx) {
             mensaje = sgpEx.getMessage();
             severity = FacesMessage.SEVERITY_ERROR;

--- a/src/main/java/mx/com/ferbo/controller/RegistroEmpleadosBean.java
+++ b/src/main/java/mx/com/ferbo/controller/RegistroEmpleadosBean.java
@@ -66,6 +66,7 @@ import mx.com.ferbo.model.DetEmpleadoConfiguracion;
 import mx.com.ferbo.model.DetEmpleadoFoto;
 import mx.com.ferbo.model.DetPercepcionEmpleado;
 import mx.com.ferbo.model.DetPrestamo;
+import mx.com.ferbo.model.DetVacaciones;
 import mx.com.ferbo.model.InfDatoEmpresa;
 import mx.com.ferbo.model.Pais;
 import mx.com.ferbo.model.sat.CatBanco;
@@ -287,6 +288,11 @@ public class RegistroEmpleadosBean implements Serializable {
 
         List<DetPrestamo> prestamos = null;
         log.info("Cargando información del empleado: {}", this.empleadoSelected);
+        this.empleadoSelected = empleadoDAO.obetenerVacacionesEmpleado(this.empleadoSelected.getIdEmpleado());   
+        if(this.empleadoSelected.getVacaciones() == null){
+            List<DetVacaciones> vacaciones = new ArrayList<DetVacaciones>();
+            this.empleadoSelected.setVacaciones(vacaciones);
+        }
         InfDatoEmpresa datoEmpresa = this.empleadoSelected.getDatoEmpresa();
         this.empleadoFoto = empleadoFotoDAO.buscar(this.empleadoSelected.getNumEmpleado());
 

--- a/src/main/java/mx/com/ferbo/dao/n/EmpleadoDAO.java
+++ b/src/main/java/mx/com/ferbo/dao/n/EmpleadoDAO.java
@@ -128,7 +128,6 @@ public class EmpleadoDAO extends BaseDAO<DetEmpleado, Integer> {
                     .getResultList();
             
             for (DetEmpleado model : modelList) {
-                log.info("Vacacaiones: {}", model.getVacaciones());
                 if (isFullInfo == false) {
                     continue;
                 }
@@ -220,5 +219,23 @@ public class EmpleadoDAO extends BaseDAO<DetEmpleado, Integer> {
         }
         
         return empleados;
+    }
+    
+    public DetEmpleado obetenerVacacionesEmpleado(Integer id) {
+        DetEmpleado model = null;
+        EntityManager emSGP = null;
+
+        try {
+            emSGP = getEntityManager();
+            model = emSGP.find(this.modelClass, id);
+                log.info("Vacaciones: {}", model.getVacaciones() == null ? null : model.getVacaciones());
+            
+        } catch (Exception ex) {
+            log.error("Problema para obtener vacaciones del empleado con id " + id, ex);
+        } finally {
+            close(emSGP);
+        }
+
+        return model;
     }
 }

--- a/src/main/webapp/protected/seccionesAsistencia/vacaciones.xhtml
+++ b/src/main/webapp/protected/seccionesAsistencia/vacaciones.xhtml
@@ -39,7 +39,7 @@
     </p:dataTable>
 
     <p:dialog widgetVar="dialogVacaciones" header="Registrar solicitud" showEffect="fade" responsive="true" modal="true" styleClass="ferbo-dialog" 
-              dynamic="true" cache="false" >
+              dynamic="true" resizable="false" width="100%" height="100%" position="center top" cache="false" >
         <p:outputPanel id="pnlDetalleVacaciones" styleClass="ui-fluid">
 
             <div class="formgrid grid">


### PR DESCRIPTION
Se corrige el problema de cargado lento de los periodos vacacionales de los empleados, en la pantalla de registro del empleado cuando se edita su información. También se ha corregido el problema del diálogo que se mostraba al empleado para registrar la solicitud de vacaciones o permiso. Por último, se ajusta el diálogo a una presentación más amigable para el usuario.