### PR TITLE
Agregar un estatus para el  registro de asistencia en dias no laborables

### DIFF
--- a/src/main/java/mx/com/ferbo/business/empleado/EmpleadoBL.java
+++ b/src/main/java/mx/com/ferbo/business/empleado/EmpleadoBL.java
@@ -4,8 +4,10 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import mx.com.ferbo.business.dianolaboral.DiasDeDescansoObligatorioBL;
 import mx.com.ferbo.dao.n.ParametroDAO;
 import mx.com.ferbo.dao.n.VacacionesDAO;
+import mx.com.ferbo.model.CatDiaNoLaboral;
 import mx.com.ferbo.model.CatParametro;
 import mx.com.ferbo.model.DetDomicilioEmpleado;
 import mx.com.ferbo.model.DetEmpleado;
@@ -22,6 +24,8 @@ import org.apache.logging.log4j.Logger;
 public class EmpleadoBL {
 
     private static final Logger log = LogManager.getLogger(EmpleadoBL.class);
+
+    private static DiasDeDescansoObligatorioBL diasDescansoAnual = new DiasDeDescansoObligatorioBL();
 
     public static void validarDatosEmpleado(DetEmpleado empleadoporvalidar) {
 
@@ -52,6 +56,40 @@ public class EmpleadoBL {
 
     }
 
+    public static List<String> diasEmpleadoTrabaja(DetEmpleado empleado){
+        List<String> diasLaboralesEmpleado = new ArrayList<String>();
+        
+        if (empleado.getDatoEmpresa().getDiaLunes()) {
+            diasLaboralesEmpleado.add("L");
+        }
+
+        if (empleado.getDatoEmpresa().getDiaMartes()) {
+            diasLaboralesEmpleado.add("M");
+        }
+
+        if (empleado.getDatoEmpresa().getDiaMiercoles()) {
+            diasLaboralesEmpleado.add("X");
+        }
+
+        if(empleado.getDatoEmpresa().getDiaJueves()){
+            diasLaboralesEmpleado.add("J");
+        }
+        
+        if(empleado.getDatoEmpresa().getDiaViernes()){
+            diasLaboralesEmpleado.add("V");
+        }
+        
+        if(empleado.getDatoEmpresa().getDiaSabado()){
+            diasLaboralesEmpleado.add("S");
+        }
+        
+        if(empleado.getDatoEmpresa().getDiaDomingo()){
+            diasLaboralesEmpleado.add("D");
+        }
+        
+        return diasLaboralesEmpleado;
+    }
+    
     public static void recalcularVacaciones(DetEmpleado empleado) throws SGPException {
 
         if (empleado.getVacaciones().isEmpty()) {
@@ -171,5 +209,28 @@ public class EmpleadoBL {
             throw new SGPException("Error: No tiene dias laborales asignados. Por favor contactar a RH");
         }
 
+    }
+
+    public static boolean empleadoAsisteEnDiaDescanso(DetEmpleado empleado) {
+        
+        List<CatDiaNoLaboral> diasDescanso = diasDescansoAnual.diasDescansoAnual();
+        List<String> diasLaboralesEmpleado = new ArrayList<String>();
+        String diaLaborando = DateUtil.getDiaSemana(DateUtil.now());
+        Date hoy = DateUtil.now();
+        DateUtil.resetTime(hoy);
+
+        diasLaboralesEmpleado = diasEmpleadoTrabaja(empleado);
+        
+        for(CatDiaNoLaboral diaDescanso : diasDescanso){
+            if(diaDescanso.getFecha().compareTo(hoy) == 0 && diaDescanso.getOficial()){
+                return true;
+            }
+        }
+        
+        if(!diasLaboralesEmpleado.contains(diaLaborando)){
+            return true;
+        }
+        
+        return false;
     }
 }

--- a/src/main/java/mx/com/ferbo/business/empleado/RegistroAsistenciaBL.java
+++ b/src/main/java/mx/com/ferbo/business/empleado/RegistroAsistenciaBL.java
@@ -143,6 +143,11 @@ public class RegistroAsistenciaBL {
         if (tipoRegistro == true) {
             log.info("Registrando entrada...");
             registro = validarConfiguracion(empleado, horaLimiteEntrada, fechaActual);
+            if (empleado.getEmpleadoConfiguracion().getAsistenciaDiaNoLaboral()) {
+                if (EmpleadoBL.empleadoAsisteEnDiaDescanso(empleado)) {
+                    registro.setIdEstatus(estatusDAO.buscarPorCodigo("X"));
+                }
+            }
             this.registroDAO.guardar(registro);
             log.info("Entrada registrada correctamente");
         }

--- a/src/main/java/mx/com/ferbo/model/DetEmpleadoConfiguracion.java
+++ b/src/main/java/mx/com/ferbo/model/DetEmpleadoConfiguracion.java
@@ -54,6 +54,10 @@ public class DetEmpleadoConfiguracion implements Serializable
     @Column(name = "st_goce_sueldo")
     private Boolean goceSueldo;
 
+    @Basic(optional = true)
+    @Column(name = "st_asistencia_nl")
+    private Boolean asistenciaDiaNoLaboral;
+    
     public DetEmpleadoConfiguracion() 
     {
     }
@@ -117,6 +121,14 @@ public class DetEmpleadoConfiguracion implements Serializable
         this.goceSueldo = goceSueldo;
     }
 
+    public Boolean getAsistenciaDiaNoLaboral() {
+        return asistenciaDiaNoLaboral;
+    }
+
+    public void setAsistenciaDiaNoLaboral(Boolean asistenciaDiaNoLaboral) {
+        this.asistenciaDiaNoLaboral = asistenciaDiaNoLaboral;
+    }
+
     @Override
     public int hashCode() 
     {
@@ -143,7 +155,7 @@ public class DetEmpleadoConfiguracion implements Serializable
 
     @Override
     public String toString() {
-        return "DetEmpleadoConfiguracion[" + "id_empleado_conf=" + idEmpleadoConf + ", empleado=" + empleado.getIdEmpleado() + ", retardo=" + retardo + ", horasextra=" + horasextra +']';
+        return "DetEmpleadoConfiguracion{" + "idEmpleadoConf=" + idEmpleadoConf + ", empleado=" + empleado.getIdEmpleado() + ", retardo=" + retardo + ", horasextra=" + horasextra + ", goceSueldo=" + goceSueldo + ", asistenciaDiaNoLaboral=" + asistenciaDiaNoLaboral + '}';
     }
     
 }

--- a/src/main/webapp/protected/registroEmpleado.xhtml
+++ b/src/main/webapp/protected/registroEmpleado.xhtml
@@ -570,6 +570,11 @@
                                                 <p:selectBooleanButton value="#{registroEmpleadosBean.empleadoSelected.empleadoConfiguracion.goceSueldo}" onLabel="Si" offLabel="No" onIcon="pi pi-check" offIcon="pi pi-times" style="width:6rem">
                                                 </p:selectBooleanButton>
                                             </div>
+                                            <div class="field col-12 md:col-3">
+                                                <p:outputLabel for="@next" value="Asistencia en dias no laborables"/><br/>
+                                                <p:selectBooleanButton value="#{registroEmpleadosBean.empleadoSelected.empleadoConfiguracion.asistenciaDiaNoLaboral}" onLabel="Si" offLabel="No" onIcon="pi pi-check" offIcon="pi pi-times" style="width:6rem">
+                                                </p:selectBooleanButton>
+                                            </div>
                                         </div>
                                     </div>
                                 </p:tab>


### PR DESCRIPTION
En la pantalla de registro de empleados, cuando se edita o agrega a un nuevo empleado, en la sección de configuración para el empleado, se ha agregado la opción para que el empleado cuando trabaje en días no laborables oficiales o en días que no están dentro de su contrato, pueda ser considerado dentro del sistema y entrar con lo establecido por los artículos que describen los días no laborables, en la ley federal del trabajo.