### PR TITLE
Modificar lógica para cancelación de incidencias

### DIFF
--- a/src/main/java/mx/com/ferbo/controller/IncidenciaBean.java
+++ b/src/main/java/mx/com/ferbo/controller/IncidenciaBean.java
@@ -31,6 +31,7 @@ import mx.com.ferbo.dao.n.EmpleadoDAO;
 import mx.com.ferbo.dao.n.EstatusRegistroDAO;
 import mx.com.ferbo.dao.n.IncidenciaDAO;
 import mx.com.ferbo.dao.n.RegistroDAO;
+import mx.com.ferbo.dao.n.RegistroVacacionesDAO;
 import mx.com.ferbo.dao.n.TipoSolicitudDAO;
 import mx.com.ferbo.model.CatEstatusIncidencia;
 import mx.com.ferbo.model.CatEstatusRegistro;
@@ -40,6 +41,7 @@ import mx.com.ferbo.model.DetDiaPermiso;
 import mx.com.ferbo.model.DetEmpleado;
 import mx.com.ferbo.model.DetIncidencia;
 import mx.com.ferbo.model.DetRegistro;
+import mx.com.ferbo.model.DetRegistroVacaciones;
 import mx.com.ferbo.model.DetSolicitudArticulo;
 import mx.com.ferbo.model.DetSolicitudPermiso;
 import mx.com.ferbo.model.DetSolicitudPrenda;
@@ -83,7 +85,7 @@ public class IncidenciaBean implements Serializable {
     private boolean estatusCancelado;
     private boolean estatusEnviado;
     private Integer diasVacacionesSolicitados;
-    
+
     private Date inicio;
     private Date fin;
     private DetRegistro registro;
@@ -118,11 +120,9 @@ public class IncidenciaBean implements Serializable {
         this.diasDeAsueto = DiasDeDescansoObligatorioBL.diasDeAsueto();
         this.registroDAO = new RegistroDAO();
         this.estatusRegistroDAO = new EstatusRegistroDAO();
-        
-        
-        
+
         /* * * * * estaba en el post-construct* * * * * * * */
-        
+
         consultaIncidencias();
         consultarRegistrosAsistencia();
         this.lstTipoSol = this.tipoSolicitudDAO.buscarActivos();
@@ -145,15 +145,15 @@ public class IncidenciaBean implements Serializable {
 
     @PostConstruct
     public void init() {
-        
+
     }
-    
+
     public void validarFechaInicioFinIncidencia() {
         if (this.periodoFin.equals(this.periodoInicio)) {
             this.periodoInicio = DateUtil.inicializaFechaInicioAnioCurso(DateUtil.getAnio(periodoFin) - 1);
         }
     }
-    
+
     private void consultaIncidencias() {
         this.lstIncidencias = incidenciaDAO.buscarTodos();
 
@@ -167,15 +167,14 @@ public class IncidenciaBean implements Serializable {
     }
 
     public List<DetIncidencia> consultarTipoPermisos()
-    throws SGPException {
+            throws SGPException {
         List<DetIncidencia> listaPeriodo = new ArrayList<DetIncidencia>();
-        
-        if(this.periodoInicio == null || this.periodoFin == null)
-        	throw new SGPException("El periodo de consulta de permisos / vacaciones es incorrecto.");
-        
+
+        if (this.periodoInicio == null || this.periodoFin == null)
+            throw new SGPException("El periodo de consulta de permisos / vacaciones es incorrecto.");
+
         listaPeriodo = this.incidenciaDAO.buscarPermisos(this.periodoInicio, this.periodoFin);
-        
-        
+
         List<DetIncidencia> listaTipoPermiso = new ArrayList<DetIncidencia>();
 
         if (this.incidenciaPermiso) {
@@ -234,8 +233,7 @@ public class IncidenciaBean implements Serializable {
         FacesMessage.Severity severity = null;
         String mensaje = null;
         String titulo = "Incidencia";
-        try
-        {
+        try {
             incidenciaSelected = solicitudIncidencia;
             empleadoSelected = solicitudIncidencia.getEmpleado();
             List<Date> fechas;
@@ -244,38 +242,39 @@ public class IncidenciaBean implements Serializable {
                 case IncidenciaBL.TP_PERMISO: // Tipo Permisos
                     EmpleadoBL.empleadoTieneDiasLaborales(incidenciaSelected.getEmpleado());
                     switch (incidenciaSelected.getSolPermiso().getTipoSolicitud().getIdTipoSolicitud()) {
-                        case 1://PERMISO
+                        case 1:// PERMISO
                             fechaSeleccionada = incidenciaSelected.getSolPermiso().getFechaInicio();
                             break;
                     }
                     this.invalidDays = IncidenciaBL.obtenerDiasSeleccionados(empleadoSelected.getDatoEmpresa());
-                    fechas = IncidenciaBL.fechasSolicitudPermiso(incidenciaSelected.getSolPermiso()); 
-                    this.diasDeVacaciones = DateUtil.diasVacacionesSolicitados(fechas, DiasDeDescansoObligatorioBL.diasDeAsueto(), empleadoSelected.getDatoEmpresa());
+                    fechas = IncidenciaBL.fechasSolicitudPermiso(incidenciaSelected.getSolPermiso());
+                    this.diasDeVacaciones = DateUtil.diasVacacionesSolicitados(fechas,
+                            DiasDeDescansoObligatorioBL.diasDeAsueto(), empleadoSelected.getDatoEmpresa());
                     log.info("Dias Solicitados: {}", this.diasDeVacaciones.toString());
                     this.diasVacacionesSolicitados = this.diasDeVacaciones.size();
                     log.info("Total Dias de Vacaciones Solicitados: {}", this.diasVacacionesSolicitados);
                     PrimeFaces.current().executeScript("PF('dialogPermisos').show();");
                     break;
-                
+
                 case IncidenciaBL.TP_VACACIONES: // Tipo Vacaciones
-                	this.incidenciaSelected = incidenciaDAO.cargar(solicitudIncidencia.getIdIncidencia())
-                		.orElseThrow(() -> new SGPException("No se encontró la incidencia solicitada."));
-                	
+                    this.incidenciaSelected = incidenciaDAO.cargar(solicitudIncidencia.getIdIncidencia())
+                            .orElseThrow(() -> new SGPException("No se encontró la incidencia solicitada."));
+
                     EmpleadoBL.empleadoTieneDiasLaborales(incidenciaSelected.getEmpleado());
                     this.invalidDays = IncidenciaBL.obtenerDiasSeleccionados(empleadoSelected.getDatoEmpresa());
-                    
+
                     fechas = this.incidenciaSelected.getSolPermiso().getDiasPermiso().stream()
-                        .map(DetDiaPermiso::getFecha)
-                        .collect(Collectors.toList());  
-                    
+                            .map(DetDiaPermiso::getFecha)
+                            .collect(Collectors.toList());
+
                     log.info("Dias Solicitados: {}", fechas.toString());
                     this.diasVacacionesSolicitados = fechas.size();
                     lstRangoRegistro = fechas;
-                    
+
                     log.info("Total Dias de Vacaciones Solicitados: {}", this.diasVacacionesSolicitados);
                     PrimeFaces.current().executeScript("PF('dialogPermisos').show();");
                     break;
-                
+
                 case IncidenciaBL.TP_PRENDA: // Tipo Prendas
                     PrimeFaces.current().executeScript("PF('dialogPrendas').show();");
                     break;
@@ -286,16 +285,18 @@ public class IncidenciaBean implements Serializable {
                 default:
                     log.warn("EX-0023: Error al seleccionar opción");
             }
-        }catch (SGPException e) {
-            log.warn("Error al abrir el registro de incidencia del empleado: {}", empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
+        } catch (SGPException e) {
+            log.warn("Error al abrir el registro de incidencia del empleado: {}",
+                    empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
             log.warn("EX-0032: {}, ", e.getMessage());
             mensaje = "Consulte al administrador de sistemas";
             severity = FacesMessage.SEVERITY_ERROR;
             message = new FacesMessage(severity, titulo, mensaje);
             FacesContext.getCurrentInstance().addMessage(null, message);
             PrimeFaces.current().ajax().update("formIncidencias:messages");
-        } catch(Exception ex) {
-        	log.warn("Error al abrir el registro de incidencia del empleado: {}", empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
+        } catch (Exception ex) {
+            log.warn("Error al abrir el registro de incidencia del empleado: {}",
+                    empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
             mensaje = "Consulte al administrador de sistemas";
             severity = FacesMessage.SEVERITY_ERROR;
             message = new FacesMessage(severity, titulo, mensaje);
@@ -318,39 +319,42 @@ public class IncidenciaBean implements Serializable {
         FacesMessage.Severity severity = null;
         String mensaje = null;
         String titulo = "Incidencia";
-        
+
         try {
             BigDecimal valor = null;
-            if(incidenciaSelected.getEmpleado().getEmpleadoConfiguracion().getGoceSueldo() == false) {
+            if (incidenciaSelected.getEmpleado().getEmpleadoConfiguracion().getGoceSueldo() == false) {
                 valor = BigDecimal.ZERO;
-            }else{
+            } else {
                 if (this.sGoceSueldo != null && !this.sGoceSueldo.isEmpty()) {
                     valor = new BigDecimal(this.sGoceSueldo);
                 }
             }
-            
+
             incidenciaSelected.setEstatusIncidencia(EstatusIncidenciaBL.estatusAprobado());
-            incidenciaSelected.getSolPermiso().setEstatus(EstatusSolicitudBL.estatusAprobado());  
+            incidenciaSelected.getSolPermiso().setEstatus(EstatusSolicitudBL.estatusAprobado());
             incidenciaSelected.getSolPermiso().setGoceSueldo(valor);
             incidenciaSelected.setEmpleadoRev(empleadoSelected);
             incidenciaSelected.setFechaMod(new Date());
             incidenciaSelected.getSolPermiso().setFechaMod(new Date());
             incidenciaSelected.getSolPermiso().setEmpleadoRev(empleadoSelected);
-            
-            if(incidenciaSelected.getEstatusIncidencia().getClave().trim().matches("A")) {
-                RegistroBL.guardarRegistroVacaciones(empleadoSelected, incidenciaSelected, DiasDeDescansoObligatorioBL.diasDeAsueto());
+
+            if (incidenciaSelected.getEstatusIncidencia().getClave().trim().matches("A")) {
+                RegistroBL.guardarRegistroVacaciones(empleadoSelected, incidenciaSelected,
+                        DiasDeDescansoObligatorioBL.diasDeAsueto());
             }
-            
+
             incidenciaDAO.actualizar(incidenciaSelected);
-            log.info("Dias solicitados del empleado {} son: {}", empleadoSelected.getIdEmpleado(), this.diasVacacionesSolicitados);
+            log.info("Dias solicitados del empleado {} son: {}", empleadoSelected.getIdEmpleado(),
+                    this.diasVacacionesSolicitados);
             mensaje = "Solicitud aprobada correctamente";
             severity = FacesMessage.SEVERITY_INFO;
         } catch (SGPException ex) {
-            log.warn("Error al guardar el status del registro de la incidencia del empleado: {}", empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
+            log.warn("Error al guardar el status del registro de la incidencia del empleado: {}",
+                    empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
             log.warn(ex.getMessage());
             mensaje = "Error al actualizar la solicitud";
             severity = FacesMessage.SEVERITY_ERROR;
-        }finally{
+        } finally {
             consultaIncidencias();
             message = new FacesMessage(severity, titulo, mensaje);
             FacesContext.getCurrentInstance().addMessage(null, message);
@@ -358,25 +362,25 @@ public class IncidenciaBean implements Serializable {
             PrimeFaces.current().executeScript("PF('dialogPermisos').hide()");
         }
     }
-    
+
     public void rechazarIncidencia() {
         FacesMessage message = null;
         FacesMessage.Severity severity = null;
         String mensaje = null;
         String titulo = "Incidencia";
-        
+
         try {
             this.incidenciaSelected.setEstatusIncidencia(EstatusIncidenciaBL.estatusRechazado());
             this.incidenciaSelected.setEmpleadoRev(empleadoSelected);
             this.incidenciaSelected.setFechaMod(new Date());
-            
+
             this.incidenciaSelected.getSolPermiso().setFechaMod(new Date());
             this.incidenciaSelected.getSolPermiso().setEstatus(EstatusSolicitudBL.estatusRechazado());
             this.incidenciaSelected.getSolPermiso().setEmpleadoRev(this.empleadoSelected);
             this.incidenciaSelected.getSolPermiso().setDescripcionRechazo(this.descripcionRechazo);
-            
+
             incidenciaDAO.actualizar(incidenciaSelected);
-            
+
             severity = FacesMessage.SEVERITY_INFO;
             mensaje = "Incidencia rechazada";
         } catch (SGPException sgpEx) {
@@ -397,62 +401,58 @@ public class IncidenciaBean implements Serializable {
         String mensaje = null;
         String titulo = "Incidencia";
         try {
-            incidenciaSelected.setEmpleadoRev(new DetEmpleado(empleadoSelected.getIdEmpleado()));
-            incidenciaSelected.setEstatusIncidencia(EstatusIncidenciaBL.estatusCancelado());
-            incidenciaSelected.setFechaMod(new Date());
-            incidenciaSelected.getSolPermiso().setEstatus(EstatusSolicitudBL.estatusCancelado());
-            incidenciaSelected.getSolPermiso().setFechaMod(new Date());
-            incidenciaSelected.getSolPermiso().setEmpleadoRev(new DetEmpleado(empleadoSelected.getIdEmpleado()));
-            
-            log.info("SolicitudPermiso: {}", incidenciaSelected.getTipoIncidencia().toString());
-            String clave = "";
-            switch(incidenciaSelected.getTipoIncidencia().getClave().trim())
-            {
-                case "PE":
-                    clave += "P";
-                    break;
-                case "V":
-                    clave += "V";
-                    break;
-                default:
-                    throw new SGPException("No hay solicitudes de vacaciones y/o permiso, contacte a su administrador de sistemas");
+
+            String tipoIncidencia = incidenciaSelected.getSolPermiso().getTipoSolicitud().getClave();
+
+            if ("V".equals(tipoIncidencia)) {
+                cancelarIncidenciaVacaciones();
+            } else {
+
+                incidenciaSelected.setEmpleadoRev(new DetEmpleado(empleadoSelected.getIdEmpleado()));
+                incidenciaSelected.setEstatusIncidencia(EstatusIncidenciaBL.estatusCancelado());
+                incidenciaSelected.setFechaMod(new Date());
+                incidenciaSelected.getSolPermiso().setEstatus(EstatusSolicitudBL.estatusCancelado());
+                incidenciaSelected.getSolPermiso().setFechaMod(new Date());
+                incidenciaSelected.getSolPermiso().setEmpleadoRev(new DetEmpleado(empleadoSelected.getIdEmpleado()));
+
+                log.info("SolicitudPermiso: {}", incidenciaSelected.getTipoIncidencia().toString());
+                String clave = "";
+                switch (incidenciaSelected.getTipoIncidencia().getClave().trim()) {
+                    case "PE":
+                        clave += "P";
+                        break;
+                    case "V":
+                        clave += "V";
+                        break;
+                    default:
+                        throw new SGPException(
+                                "No hay solicitudes de vacaciones y/o permiso, contacte a su administrador de sistemas");
+                }
+
+                incidenciaDAO.actualizar(incidenciaSelected);
             }
-            
-//            List<DetRegistro> registroIncidencias = RegistroBL.obtenerRegistroAsistencia(empleadoSelected, incidenciaSelected.getSolPermiso().getFechaInicio(), incidenciaSelected.getSolPermiso().getFechaFin(), clave);
-            List<DetRegistro> registroIncidencias = RegistroBL.buscarRegistrosVacaciones(this.incidenciaSelected);
-            int registrosEliminados = RegistroBL.cancelarRegistroAsistencia(registroIncidencias);
-            log.info("Registros eliminados {} del empleado {}", registrosEliminados, empleadoSelected.getIdEmpleado());
-            
-            if(incidenciaSelected.getSolPermiso().getVacaciones() != null) {
-            	
-            	List<Date> diasPermiso = incidenciaSelected.getSolPermiso().getDiasPermiso().stream()
-            			.map(item -> item.getFecha())
-            			.collect(Collectors.toList());
-            	
-            	incidenciaSelected.getSolPermiso().getVacaciones().getRegistroVacaciones().stream()
-            	.forEach(item -> {
-            		if(item.getRegistro() == null)
-            			return;
-            		
-            		Date fecha = new Date(item.getRegistro().getFechaEntrada().getTime());
-            		DateUtil.resetTime(fecha);
-            		
-            		if( ! diasPermiso.contains(fecha) )
-            			return;
-            		item.setRegistro(null);
-            	});
-            }
-            
-            incidenciaDAO.actualizar(incidenciaSelected);
-            
+
             mensaje = "Solicitud cancelada correctamente";
             severity = FacesMessage.SEVERITY_INFO;
         } catch (SGPException ex) {
-            log.warn("Error al guardar el status del registro de la incidencia del empleado: {}", empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
+            log.warn("Error al guardar el status del registro de la incidencia del empleado: {}",
+                    empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
             log.warn("EX-0028: ", ex);
-            mensaje = "Error al actualizar la solicitud";
-            severity = FacesMessage.SEVERITY_ERROR;
-        } finally{
+            mensaje = ex.getMessage();
+            severity = FacesMessage.SEVERITY_WARN;
+        } catch (RuntimeException ex) {
+            log.warn("Error al guardar el status del registro de la incidencia del empleado: {}",
+                    empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
+            log.warn("EX-0028: ", ex);
+            mensaje = ex.getMessage();
+            severity = FacesMessage.SEVERITY_WARN;
+        } catch (Exception ex) {
+            log.warn("Error al guardar el status del registro de la incidencia del empleado: {}",
+                    empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
+            log.warn("EX-0028: ", ex);
+            mensaje = "Error desconocido, contacte con el administrador se sistemas";
+            severity = FacesMessage.SEVERITY_WARN;
+        } finally {
             consultaIncidencias();
             message = new FacesMessage(severity, titulo, mensaje);
             FacesContext.getCurrentInstance().addMessage(null, message);
@@ -461,37 +461,82 @@ public class IncidenciaBean implements Serializable {
         }
     }
 
+    public void cancelarIncidenciaVacaciones() throws SGPException, RuntimeException, Exception {
+
+        Date inicioPeriodoVacacional = incidenciaSelected.getSolPermiso().getFechaInicio();
+        Date finPeriodoVacacional = incidenciaSelected.getSolPermiso().getFechaFin();
+
+        DateUtil.setTime(inicioPeriodoVacacional, 0, 0, 0, 0);
+        DateUtil.setTime(finPeriodoVacacional, 23, 59, 59);
+
+        Date hoy = new Date();
+        DateUtil.setTime(hoy, 0, 0, 0);
+
+        if (finPeriodoVacacional.before(hoy)) {
+            throw new RuntimeException("El periodo vacacional ya ha concluido");
+        }
+
+        incidenciaSelected.setEmpleadoRev(new DetEmpleado(empleadoSelected.getIdEmpleado()));
+        incidenciaSelected.setEstatusIncidencia(EstatusIncidenciaBL.estatusCancelado());
+        incidenciaSelected.setFechaMod(new Date());
+        incidenciaSelected.getSolPermiso().setEstatus(EstatusSolicitudBL.estatusCancelado());
+        incidenciaSelected.getSolPermiso().setFechaMod(new Date());
+        incidenciaSelected.getSolPermiso().setEmpleadoRev(new DetEmpleado(empleadoSelected.getIdEmpleado()));
+        incidenciaDAO.actualizar(incidenciaSelected);
+
+        if (inicioPeriodoVacacional.after(hoy)) {
+
+            List<DetRegistro> registros = RegistroBL.buscarRegistrosVacaciones(incidenciaSelected);
+
+            RegistroVacacionesDAO registroVacacionesDAO = new RegistroVacacionesDAO();
+
+            for (DetRegistro registro : registros) {
+                DetRegistroVacaciones registroVacacion = registro.getRegistroVacaciones();
+                registroVacacionesDAO.eliminar(registroVacacion);
+                registroDAO.eliminar(registro);
+            }
+
+        }
+
+        if (inicioPeriodoVacacional.before(hoy) && finPeriodoVacacional.after(hoy)) {
+            throw new SGPException("El periodo esta en curso, no se eliminaran los registros");
+        }
+
+    }
+
     public void guardarEstatusArticulo(boolean aprobada) {
         FacesMessage message = null;
         FacesMessage.Severity severity = null;
         String mensaje = null;
         String titulo = "Incidencia";
         try {
-            if(aprobada){
+            if (aprobada) {
                 incidenciaSelected.setEstatusIncidencia(EstatusIncidenciaBL.estatusAprobado());
                 incidenciaSelected.getSolArticulo().setEstatus(EstatusSolicitudBL.estatusAprobado());
                 mensaje = "Solicitud aprobada correctamente";
-            }else if(!aprobada){
+            } else if (!aprobada) {
                 incidenciaSelected.setEstatusIncidencia(EstatusIncidenciaBL.estatusRechazado());
                 incidenciaSelected.getSolArticulo().setEstatus(EstatusSolicitudBL.estatusRechazado());
                 mensaje = "Solicitud rechazada correctamente";
             }
             incidenciaSelected.setFechaMod(new Date());
             incidenciaSelected.getSolArticulo().setFechaMod(new Date());
-            incidenciaSelected.getSolArticulo().setEmpleadoRev(empleadoSelected);  
+            incidenciaSelected.getSolArticulo().setEmpleadoRev(empleadoSelected);
             incidenciaDAO.actualizar(incidenciaSelected);
-            
+
             severity = FacesMessage.SEVERITY_INFO;
         } catch (SGPException ex) {
-            log.warn("Error al guardar el status del registro del artículo del empleado: {}", empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
+            log.warn("Error al guardar el status del registro del artículo del empleado: {}",
+                    empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
             log.warn("EX-0029: ", ex);
             mensaje = "Error al actualizar la solicitud";
             severity = FacesMessage.SEVERITY_ERROR;
-        } finally{
+        } finally {
             consultaIncidencias();
             message = new FacesMessage(severity, titulo, mensaje);
             FacesContext.getCurrentInstance().addMessage(null, message);
-            PrimeFaces.current().ajax().update("formIncidencias:messages", "formIncidencias:tabViewI:dtArticulosSolicitados");
+            PrimeFaces.current().ajax().update("formIncidencias:messages",
+                    "formIncidencias:tabViewI:dtArticulosSolicitados");
             PrimeFaces.current().executeScript("PF('dialogArticulos').hide()");
         }
     }
@@ -502,11 +547,11 @@ public class IncidenciaBean implements Serializable {
         String mensaje = null;
         String titulo = "Incidencia";
         try {
-            if(aprobada){
+            if (aprobada) {
                 incidenciaSelected.setEstatusIncidencia(EstatusIncidenciaBL.estatusAprobado());
                 incidenciaSelected.getSolPrenda().setEstatus(EstatusSolicitudBL.estatusAprobado());
                 mensaje = "Solicitud aprobada correctamente";
-            }else if(!aprobada){
+            } else if (!aprobada) {
                 incidenciaSelected.setEstatusIncidencia(EstatusIncidenciaBL.estatusRechazado());
                 incidenciaSelected.getSolPrenda().setEstatus(EstatusSolicitudBL.estatusRechazado());
                 mensaje = "Solicitud rechazada correctamente";
@@ -518,81 +563,79 @@ public class IncidenciaBean implements Serializable {
 
             severity = FacesMessage.SEVERITY_INFO;
         } catch (SGPException ex) {
-            log.warn("Error al guardar el status del registro de la prenda del empleado: {}", empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
+            log.warn("Error al guardar el status del registro de la prenda del empleado: {}",
+                    empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
             log.warn("EX-0030: ", ex);
             mensaje = "Error al actualizar la solicitud, contacte al administrador de sistemas";
             severity = FacesMessage.SEVERITY_ERROR;
-        } finally{
+        } finally {
             consultaIncidencias();
             message = new FacesMessage(severity, titulo, mensaje);
             FacesContext.getCurrentInstance().addMessage(null, message);
-            PrimeFaces.current().ajax().update("formIncidencias:messages", "formIncidencias:tabViewI:dtPrendasSolicitados");
+            PrimeFaces.current().ajax().update("formIncidencias:messages",
+                    "formIncidencias:tabViewI:dtPrendasSolicitados");
             PrimeFaces.current().executeScript("PF('dialogPrendas').hide()");
         }
     }
-    
-    public void consultarRegistrosAsistencia()
-    {
+
+    public void consultarRegistrosAsistencia() {
         this.estatusRegJustificado = estatusRegistroDAO.buscarPorCodigo(justificado);
     }
-    
+
     public void validarFechaInicioFinRegistro() {
         if (this.fin.equals(this.inicio)) {
             this.inicio = DateUtil.inicializaFechaInicioAnioCurso(DateUtil.getAnio(fin) - 1);
         }
     }
-    
-    public List<DetRegistro> consultarRegistros()
-    {
+
+    public List<DetRegistro> consultarRegistros() {
         List<DetRegistro> listaPeriodo = new ArrayList<DetRegistro>();
-        
+
         if (this.inicio != null && this.fin != null) {
             listaPeriodo = this.listRegistro.stream()
-                    .filter(objeto -> objeto.getFechaEntrada().compareTo(this.inicio) == 0 || objeto.getFechaEntrada().compareTo(this.inicio) > 0) 
-                    .filter(objeto -> objeto.getFechaEntrada().compareTo(this.fin) == 0 || objeto.getFechaEntrada().compareTo(this.fin) < 0)
+                    .filter(objeto -> objeto.getFechaEntrada().compareTo(this.inicio) == 0
+                            || objeto.getFechaEntrada().compareTo(this.inicio) > 0)
+                    .filter(objeto -> objeto.getFechaEntrada().compareTo(this.fin) == 0
+                            || objeto.getFechaEntrada().compareTo(this.fin) < 0)
                     .collect(Collectors.toList());
         }
-        
+
         List<DetRegistro> listaEmpleado = new ArrayList<DetRegistro>();
-        
-        if(this.empleadoAsistenciaTXT.equals(""))
-        {
+
+        if (this.empleadoAsistenciaTXT.equals("")) {
             listaEmpleado = listaPeriodo;
         }
-        
-        if (this.empleadoAsistenciaTXT != null && !this.empleadoAsistenciaTXT.equals("")) 
-        {
-            listaEmpleado = listaPeriodo.stream().
-                    filter(objeto -> objeto.getIdEmpleado().getNombre().contains(this.empleadoAsistenciaTXT.trim().toUpperCase()) 
-                            || objeto.getIdEmpleado().getPrimerAp().contains(this.empleadoAsistenciaTXT.trim().toUpperCase()) 
-                            || objeto.getIdEmpleado().getSegundoAp().contains(this.empleadoAsistenciaTXT.trim().toUpperCase())).
-                    collect(Collectors.toList());
+
+        if (this.empleadoAsistenciaTXT != null && !this.empleadoAsistenciaTXT.equals("")) {
+            listaEmpleado = listaPeriodo.stream().filter(objeto -> objeto.getIdEmpleado().getNombre()
+                    .contains(this.empleadoAsistenciaTXT.trim().toUpperCase())
+                    || objeto.getIdEmpleado().getPrimerAp().contains(this.empleadoAsistenciaTXT.trim().toUpperCase())
+                    || objeto.getIdEmpleado().getSegundoAp().contains(this.empleadoAsistenciaTXT.trim().toUpperCase()))
+                    .collect(Collectors.toList());
         }
-        
+
         return listaEmpleado;
     }
-    
-    public void editarRegistro(DetRegistro registroAsistencia)
-    {
+
+    public void editarRegistro(DetRegistro registroAsistencia) {
         this.registro = registroAsistencia;
         log.info("Editando un registro de asistencia: {}", this.registro);
     }
-    
-    public void actualizarRegistro()
-    {
+
+    public void actualizarRegistro() {
         FacesMessage message = null;
         FacesMessage.Severity severity = null;
         String mensaje = null;
         String titulo = "Registro";
-        try 
-        {
+        try {
             this.registro.setStatus(estatusRegJustificado);
             RegistroBL.actualizarRegistroAsistencia(this.registro);
             mensaje = "Se actualizo el registro de asistencia";
             severity = FacesMessage.SEVERITY_INFO;
             PrimeFaces.current().executeScript("PF('dialogoJustificar').hide()");
         } catch (SGPException ex) {
-            log.warn("Error al guardar el registro de asistencia del empleado: {}", empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
+            log.warn("Error al guardar el registro de asistencia del empleado: {}",
+                    empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
             log.warn("EX-0030: ", ex);
             mensaje = "Error al actualizar el registro, contacte al administrador de sistemas";
             severity = FacesMessage.SEVERITY_ERROR;
@@ -603,98 +646,97 @@ public class IncidenciaBean implements Serializable {
             PrimeFaces.current().ajax().update("formIncidencias:messages", "formIncidencias:tabViewI:dtRegistro");
         }
     }
-    
+
     public boolean permiteAprobar() {
-    	boolean respuesta = false;
-    	if(this.incidenciaSelected == null)
-    		return false;
-    	
-    	if(this.incidenciaSelected.getSolPermiso() == null)
-    		return false;
-    	
-    	if(this.incidenciaSelected.getEstatusIncidencia() == null)
-    		return false;
-    	
-    	if(this.incidenciaSelected.getEstatusIncidencia().getClave() == null)
-    		return false;
-    	
-    	switch(this.incidenciaSelected.getEstatusIncidencia().getClave()) {
-    	case IncidenciaBL.ST_ENVIADA:
-    		respuesta = true;
-    		break;
-    	case IncidenciaBL.ST_APROBADA:
-    	case IncidenciaBL.ST_RECHAZADA:
-    	case IncidenciaBL.ST_CANCELADA:
-    		respuesta = false;
-    		break;
-		default:
-			respuesta = false;
-    	}
-    	
-    	return respuesta;
+        boolean respuesta = false;
+        if (this.incidenciaSelected == null)
+            return false;
+
+        if (this.incidenciaSelected.getSolPermiso() == null)
+            return false;
+
+        if (this.incidenciaSelected.getEstatusIncidencia() == null)
+            return false;
+
+        if (this.incidenciaSelected.getEstatusIncidencia().getClave() == null)
+            return false;
+
+        switch (this.incidenciaSelected.getEstatusIncidencia().getClave()) {
+            case IncidenciaBL.ST_ENVIADA:
+                respuesta = true;
+                break;
+            case IncidenciaBL.ST_APROBADA:
+            case IncidenciaBL.ST_RECHAZADA:
+            case IncidenciaBL.ST_CANCELADA:
+                respuesta = false;
+                break;
+            default:
+                respuesta = false;
+        }
+
+        return respuesta;
     }
-    
+
     public boolean permiteRechazar() {
-    	boolean respuesta = false;
-    	if(this.incidenciaSelected == null)
-    		return false;
-    	
-    	if(this.incidenciaSelected.getSolPermiso() == null)
-    		return false;
-    	
-    	if(this.incidenciaSelected.getEstatusIncidencia() == null)
-    		return false;
-    	
-    	if(this.incidenciaSelected.getEstatusIncidencia().getClave() == null)
-    		return false;
-    	
-    	switch(this.incidenciaSelected.getEstatusIncidencia().getClave()) {
-    	case IncidenciaBL.ST_ENVIADA:
-    		respuesta = true;
-    		break;
-    	case IncidenciaBL.ST_APROBADA:
-    	case IncidenciaBL.ST_RECHAZADA:
-    	case IncidenciaBL.ST_CANCELADA:
-    		respuesta = false;
-    		break;
-		default:
-			respuesta = false;
-    	}
-    	
-    	return respuesta;
+        boolean respuesta = false;
+        if (this.incidenciaSelected == null)
+            return false;
+
+        if (this.incidenciaSelected.getSolPermiso() == null)
+            return false;
+
+        if (this.incidenciaSelected.getEstatusIncidencia() == null)
+            return false;
+
+        if (this.incidenciaSelected.getEstatusIncidencia().getClave() == null)
+            return false;
+
+        switch (this.incidenciaSelected.getEstatusIncidencia().getClave()) {
+            case IncidenciaBL.ST_ENVIADA:
+                respuesta = true;
+                break;
+            case IncidenciaBL.ST_APROBADA:
+            case IncidenciaBL.ST_RECHAZADA:
+            case IncidenciaBL.ST_CANCELADA:
+                respuesta = false;
+                break;
+            default:
+                respuesta = false;
+        }
+
+        return respuesta;
     }
-    
+
     public boolean permiteCancelar() {
-    	boolean respuesta = false;
-    	if(this.incidenciaSelected == null)
-    		return false;
-    	
-    	if(this.incidenciaSelected.getSolPermiso() == null)
-    		return false;
-    	
-    	if(this.incidenciaSelected.getEstatusIncidencia() == null)
-    		return false;
-    	
-    	if(this.incidenciaSelected.getEstatusIncidencia().getClave() == null)
-    		return false;
-    	
-    	switch(this.incidenciaSelected.getEstatusIncidencia().getClave()) {
-    	case IncidenciaBL.ST_APROBADA:
-    		respuesta = true;
-    		break;
-    	case IncidenciaBL.ST_ENVIADA:
-    	case IncidenciaBL.ST_RECHAZADA:
-    	case IncidenciaBL.ST_CANCELADA:
-    		respuesta = false;
-    		break;
-		default:
-			respuesta = false;
-    	}
-    	
-    	return respuesta;
+        boolean respuesta = false;
+        if (this.incidenciaSelected == null)
+            return false;
+
+        if (this.incidenciaSelected.getSolPermiso() == null)
+            return false;
+
+        if (this.incidenciaSelected.getEstatusIncidencia() == null)
+            return false;
+
+        if (this.incidenciaSelected.getEstatusIncidencia().getClave() == null)
+            return false;
+
+        switch (this.incidenciaSelected.getEstatusIncidencia().getClave()) {
+            case IncidenciaBL.ST_APROBADA:
+                respuesta = true;
+                break;
+            case IncidenciaBL.ST_ENVIADA:
+            case IncidenciaBL.ST_RECHAZADA:
+            case IncidenciaBL.ST_CANCELADA:
+                respuesta = false;
+                break;
+            default:
+                respuesta = false;
+        }
+
+        return respuesta;
     }
-    
-    
+
     public DetIncidencia getIncidenciaSelected() {
         return incidenciaSelected;
     }
@@ -878,7 +920,7 @@ public class IncidenciaBean implements Serializable {
     public List<Date> getDiasDeAsueto() {
         return diasDeAsueto;
     }
-    
+
     public List<Date> getDiasDeVacaciones() {
         return diasDeVacaciones;
     }
@@ -886,7 +928,7 @@ public class IncidenciaBean implements Serializable {
     public void setDiasDeVacaciones(List<Date> diasDeVacaciones) {
         this.diasDeVacaciones = diasDeVacaciones;
     }
-    
+
     public String getsGoceSueldo() {
         return sGoceSueldo;
     }
@@ -902,7 +944,7 @@ public class IncidenciaBean implements Serializable {
     public void setDescripcionRechazo(String descripcionRechazo) {
         this.descripcionRechazo = descripcionRechazo;
     }
-    
+
     public DetRegistro getRegistro() {
         return registro;
     }
@@ -910,7 +952,7 @@ public class IncidenciaBean implements Serializable {
     public void setRegistro(DetRegistro registro) {
         this.registro = registro;
     }
-    
+
     public List<DetRegistro> getListRegistro() {
         return listRegistro;
     }
@@ -926,7 +968,7 @@ public class IncidenciaBean implements Serializable {
     public void setListRegistroFiltrada(List<DetRegistro> listRegistroFiltrada) {
         this.listRegistroFiltrada = listRegistroFiltrada;
     }
-    
+
     public Date getInicio() {
         return inicio;
     }
@@ -942,7 +984,7 @@ public class IncidenciaBean implements Serializable {
     public void setFin(Date fin) {
         this.fin = fin;
     }
-    
+
     public String getEmpleadoAsistenciaTXT() {
         return empleadoAsistenciaTXT;
     }
@@ -950,5 +992,5 @@ public class IncidenciaBean implements Serializable {
     public void setEmpleadoAsistenciaTXT(String empleadoAsistenciaTXT) {
         this.empleadoAsistenciaTXT = empleadoAsistenciaTXT;
     }
-    //</editor-fold>
+    // </editor-fold>
 }

--- a/src/main/java/mx/com/ferbo/controller/IncidenciaBean.java
+++ b/src/main/java/mx/com/ferbo/controller/IncidenciaBean.java
@@ -263,11 +263,15 @@ public class IncidenciaBean implements Serializable {
                 	
                     EmpleadoBL.empleadoTieneDiasLaborales(incidenciaSelected.getEmpleado());
                     this.invalidDays = IncidenciaBL.obtenerDiasSeleccionados(empleadoSelected.getDatoEmpresa());
-                    fechas = IncidenciaBL.fechasSolicitudPermiso(incidenciaSelected.getSolPermiso());
-                    this.diasDeVacaciones = DateUtil.diasVacacionesSolicitados(fechas, DiasDeDescansoObligatorioBL.diasDeAsueto(), empleadoSelected.getDatoEmpresa());
-                    log.info("Dias Solicitados: {}", this.diasDeVacaciones.toString());
-                    this.diasVacacionesSolicitados = this.diasDeVacaciones.size();
-                    lstRangoRegistro = Arrays.asList(diasDeVacaciones.get(0), diasDeVacaciones.get(this.diasVacacionesSolicitados - 1));
+                    
+                    fechas = this.incidenciaSelected.getSolPermiso().getDiasPermiso().stream()
+                        .map(DetDiaPermiso::getFecha)
+                        .collect(Collectors.toList());  
+                    
+                    log.info("Dias Solicitados: {}", fechas.toString());
+                    this.diasVacacionesSolicitados = fechas.size();
+                    lstRangoRegistro = fechas;
+                    
                     log.info("Total Dias de Vacaciones Solicitados: {}", this.diasVacacionesSolicitados);
                     PrimeFaces.current().executeScript("PF('dialogPermisos').show();");
                     break;

--- a/src/main/java/mx/com/ferbo/controller/IncidenciaBean.java
+++ b/src/main/java/mx/com/ferbo/controller/IncidenciaBean.java
@@ -445,13 +445,13 @@ public class IncidenciaBean implements Serializable {
                     empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
             log.warn("EX-0028: ", ex);
             mensaje = ex.getMessage();
-            severity = FacesMessage.SEVERITY_WARN;
+            severity = FacesMessage.SEVERITY_ERROR;
         } catch (Exception ex) {
             log.warn("Error al guardar el status del registro de la incidencia del empleado: {}",
                     empleadoSelected.getNumEmpleado() != null ? empleadoSelected.getNumEmpleado() : null);
             log.warn("EX-0028: ", ex);
             mensaje = "Error desconocido, contacte con el administrador se sistemas";
-            severity = FacesMessage.SEVERITY_WARN;
+            severity = FacesMessage.SEVERITY_ERROR;
         } finally {
             consultaIncidencias();
             message = new FacesMessage(severity, titulo, mensaje);

--- a/src/main/java/mx/com/ferbo/model/DetIncidencia.java
+++ b/src/main/java/mx/com/ferbo/model/DetIncidencia.java
@@ -208,7 +208,7 @@ public class DetIncidencia implements Serializable {
 
     @Override
     public String toString() {
-        return "DetIncidencia[" + "idIncidencia=" + idIncidencia + ", idEmpleado=" + empleado.getIdEmpleado() + 
+        return "DetIncidencia[" + "idIncidencia=" + idIncidencia + ", idEmpleado=" + ((empleado != null) ? empleado.getIdEmpleado() : "null")+ 
                 ", idEmpleadoRev=" + ((empleadoRev != null) ? empleadoRev.getIdEmpleado() : "null") + ", visible=" + visible + 
                 ", idEstatus=" + estatusIncidencia.getClave() + ", idTipo=" + tipoIncidencia.getClave() + 
                 ", idSolArticulo=" + ((solArticulo != null) ? solArticulo.getIdSolicitud() : "null") + 

--- a/src/main/java/mx/com/ferbo/model/DetRegistro.java
+++ b/src/main/java/mx/com/ferbo/model/DetRegistro.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.Objects;
 
 import javax.persistence.Basic;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -14,6 +15,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
@@ -65,8 +67,8 @@ public class DetRegistro implements Serializable {
     @ManyToOne(optional = false)
     private DetEmpleado idEmpleado;
     
-//    @OneToOne(optional = true, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
-//    private DetRegistroVacaciones registroVacaciones;
+    @OneToOne(mappedBy = "registro", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private DetRegistroVacaciones registroVacaciones;
     
     @Override
 	public int hashCode() {
@@ -155,11 +157,11 @@ public class DetRegistro implements Serializable {
         this.idEmpleado = idEmpleado;
     }
 
-//	public DetRegistroVacaciones getRegistroVacaciones() {
-//		return registroVacaciones;
-//	}
-//
-//	public void setRegistroVacaciones(DetRegistroVacaciones registroVacaciones) {
-//		this.registroVacaciones = registroVacaciones;
-//	}
+    public DetRegistroVacaciones getRegistroVacaciones() {
+		return registroVacaciones;
+    }
+
+	public void setRegistroVacaciones(DetRegistroVacaciones registroVacaciones) {
+        this.registroVacaciones = registroVacaciones;
+    }
 }

--- a/src/main/java/mx/com/ferbo/model/DetRegistroVacaciones.java
+++ b/src/main/java/mx/com/ferbo/model/DetRegistroVacaciones.java
@@ -15,6 +15,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
+
 @Entity
 @Table(name = "det_registro_vacaciones")
 public class DetRegistroVacaciones implements Serializable {

--- a/src/main/webapp/protected/seccionesIncidencias/incidencia.xhtml
+++ b/src/main/webapp/protected/seccionesIncidencias/incidencia.xhtml
@@ -130,11 +130,11 @@
                     </div>
                 </p:panel>
             </div>
-            <p:datePicker id="dpRangoView" rendered="#{incidenciaBean.incidenciaSelected.solPermiso.tipoSolicitud.idTipoSolicitud ne null 
+            <p:datePicker id="lazyEvent" rendered="#{incidenciaBean.incidenciaSelected.solPermiso.tipoSolicitud.idTipoSolicitud ne null 
                                                        and (incidenciaBean.incidenciaSelected.solPermiso.tipoSolicitud.idTipoSolicitud eq 2 
                                                        or incidenciaBean.incidenciaSelected.solPermiso.tipoSolicitud.idTipoSolicitud eq 4)}" 
                           styleClass="ferbo-datePicker" panelStyleClass="ferbo-datePicker-panel" locale="es" disabled="false" 
-                          showIcon="true" readonlyInput="true" value="#{incidenciaBean.incidenciaSelected.solPermiso.diasPermiso}" showMinMaxRange="true" 
+                          showIcon="true" readonlyInput="true" value="#{incidenciaBean.lstRangoRegistro}" showMinMaxRange="true" 
                           mindate="#{incidenciaBean.incidenciaSelected.solPermiso.fechaInicio}" maxdate="#{incidenciaBean.incidenciaSelected.solPermiso.fechaFin}"
                           inline="true" selectionMode="multiple" disabledDays="#{incidenciaBean.invalidDays}"
                           disabledDates="#{incidenciaBean.diasDeAsueto}"/>


### PR DESCRIPTION
En la pantalla de incidencias, cuando se entra en la sección Vacaciones/Permisos, al momento de seleccionar una incidencia de vacaciones aceptada, si se da clic al botón cancelar se ha cambiado la forma de interacción: 

* Si el periodo vacacional ya ha terminado antes de la fecha de hoy, no se puede cancelar y se manda un mensaje indicando que el periodo vacacional ya ha concluido.
* Si el periodo vacacional está en curso, solamente simplemente se cambia el estatus de la incidencia, y se manda un mensaje que el periodo está en curso. 
* Si el periodo vacacional esta a fututo, se cancela la incidencia sin ningún problema, y se mande un mensaje satisfactorio.

 Si la incidencia no es de vacaciones, la incidencia de cancela de la forma tradicional.