### PR TITLE
Corrección en la consulta de asistencia para calculo de nómina semanal.

### DIFF
--- a/src/main/java/mx/com/ferbo/business/nomina/NominaSemanalBL.java
+++ b/src/main/java/mx/com/ferbo/business/nomina/NominaSemanalBL.java
@@ -614,6 +614,8 @@ public class NominaSemanalBL extends NominaBL {
 		Date                     diaNLEntrada     = null;
 		Date                     diaNLSalida      = null;
 		CatEstatusRegistro       statusDescanso   = null;
+		Date                     incidenciaInicio = null;
+		Date                     incidenciaFin    = null;
 		
 		statusRegistros = parametros.getStatusRegistros();
 		
@@ -624,7 +626,15 @@ public class NominaSemanalBL extends NominaBL {
 		
 		mapAsistencias = new HashMap<String, DetRegistro>();
 		registroDAO = new RegistroDAO();
-		listaAsistencias = registroDAO.buscar(empleado.getIdEmpleado(), parametros.getIncidenciaInicio(), parametros.getIncidenciaFin());
+		
+		if(DateUtil.isDateBetween(empleado.getDatoEmpresa().getFechaIngreso(), parametros.getIncidenciaInicio(), parametros.getIncidenciaFin()))
+			incidenciaInicio = new Date(empleado.getDatoEmpresa().getFechaIngreso().getTime());
+		else
+			incidenciaInicio = new Date(parametros.getIncidenciaInicio().getTime());
+		
+		incidenciaFin = new Date(parametros.getIncidenciaFin().getTime());
+		
+		listaAsistencias = registroDAO.buscar(empleado.getIdEmpleado(), incidenciaInicio, incidenciaFin);
 		for(DetRegistro registro : listaAsistencias) {
 			diaSemana = DateUtil.getDiaSemana(registro.getFechaEntrada());
 			if(mapAsistencias.containsKey(diaSemana))


### PR DESCRIPTION
En la consulta de asistencia para la nómina semanal, si se modificaba la fecha de ingreso (hacia adelante) para formalizar la contratación del empleado, y existían registros de asistencia previos a la fecha de inicio de relación laboral, el sistema obtenía las fechas anteriores al inicio de la relación laboral.

Se corrige la condición para evitar que registros previos a la fecha de inicio de relación laboral afecten el cálculo de séptimo día.