### PR TITLE
Ajuste en nómina semanal al agregar periodo vacacional.

### DIFF
--- a/src/main/java/mx/com/ferbo/controller/NominaSemanalBean.java
+++ b/src/main/java/mx/com/ferbo/controller/NominaSemanalBean.java
@@ -393,7 +393,7 @@ public class NominaSemanalBean implements Serializable {
 			}
 			
 			NominaBL.agregarPercepcion(nomina, primaVacacional);
-			
+			NominaBL.calcularTotales(nomina, parametros);
 			PrimeFaces.current().executeScript("PF('dlgAddPeriodoVacacional').hide();");
 		} catch(Exception ex) {
 			log.error("Problema para agregar el periodo vacacional", ex);


### PR DESCRIPTION
En la nómina semanal, al seleccionar un empleado y agregar un periodo vacacional, se calcula la prima vacacional y se actualiza el ajuste en el subtotal, descuentos y total.