### PR TITLE
Ajuste de ISR en percepciones de nómina semanal.

### DIFF
--- a/src/main/java/mx/com/ferbo/controller/NominaSemanalBean.java
+++ b/src/main/java/mx/com/ferbo/controller/NominaSemanalBean.java
@@ -713,6 +713,7 @@ public class NominaSemanalBean implements Serializable {
 		String titulo = "Nómina";
 		
     	try {
+    		NominaSemanalBL.procesarISR(this.parametros, this.nomina);
     		NominaBL.calcularTotales(nomina, parametros);
     	} catch(Exception ex) {
     		log.error("Problema para recalcular la nómina...", ex);

--- a/src/main/webapp/protected/nomina/semanal/nomina-s-empleado-percepciones.xhtml
+++ b/src/main/webapp/protected/nomina/semanal/nomina-s-empleado-percepciones.xhtml
@@ -26,17 +26,17 @@
 							</p:column>
 							<p:column headerText="Importe" width="6rem" style="text-align: right;">
 								<p:inputNumber value="#{percepcion.importe}" symbol="$ " decimalPlaces="2" decimalSeparator="." thousandSeparator="," inputStyle="text-align: right" readonly="#{nominaS.nomina.id ne null}">
-									<p:ajax process="@this" update="form:tv-nomina" event="change" listener="#{nominaS.actualizarImporte(percepcion)}"/>
+									<p:ajax process="@this" update="form:tv-nomina" event="change" listener="#{nominaS.actualizarImporte(percepcion)}" onstart="PF('statusInfoDialog').show();" oncomplete="PF('statusInfoDialog').hide();"/>
 								</p:inputNumber>
 							</p:column>
 							<p:column headerText="Exento" width="6rem" style="text-align: right;">
 								<p:inputNumber value="#{percepcion.importeExento}" symbol="$ " decimalPlaces="2" decimalSeparator="." thousandSeparator="," inputStyle="text-align: right" readonly="true">
-									<p:ajax process="@this" update="form:tv-nomina" event="change" listener="#{nominaS.actualizar()}"/>
+									<p:ajax process="@this" update="form:tv-nomina" event="change" listener="#{nominaS.actualizar()}" onstart="PF('statusInfoDialog').show();" oncomplete="PF('statusInfoDialog').hide();"/>
 								</p:inputNumber>
 							</p:column>
 							<p:column headerText="Gravado" width="6rem" style="text-align: right;">
 								<p:inputNumber value="#{percepcion.importeGravado}" symbol="$ " decimalPlaces="2" decimalSeparator="." thousandSeparator="," inputStyle="text-align: right" readonly="true">
-									<p:ajax process="@this" update="form:tv-nomina" event="change" listener="#{nominaS.actualizarPercepcion(percepcion)}"/>
+									<p:ajax process="@this" update="form:tv-nomina" event="change" listener="#{nominaS.actualizarPercepcion(percepcion)}" onstart="PF('statusInfoDialog').show();" oncomplete="PF('statusInfoDialog').hide();"/>
 								</p:inputNumber>
 							</p:column>
 							<p:column width="2rem">


### PR DESCRIPTION
En la nómina semanal:
- Al agregar manualmente una percepción al empleado, se ejecuta nuevamente el cálculo de ISR.
- Al modificar el importe de una percepción del empleado, se ejecuta nuevamente el cálculo de ISR.