### PR TITLE
Ajuste al eliminar percepción (prima vacacional) en nómina semanal.

### DIFF
--- a/src/main/java/mx/com/ferbo/business/nomina/NominaBL.java
+++ b/src/main/java/mx/com/ferbo/business/nomina/NominaBL.java
@@ -567,11 +567,19 @@ public abstract class NominaBL {
 		if(percepcion == null)
 			throw new SGPException("Debe seleccionar una percepción.");
 		
-		boolean respuesta = nomina.getPercepciones().remove(percepcion);
+		Optional<DetNominaVacaciones> periodoVacacional = null;
 		
 		if(PercepcionBL.CVE_PRIMA_VACACIONES_EN_TIEMPO.equalsIgnoreCase(percepcion.getClave())) {
-			nomina.getVacaciones().clear();
+			periodoVacacional = nomina.getNominaVacaciones().stream().filter(item -> "T".equalsIgnoreCase(item.getTipoPrima() )).findFirst();
+			nomina.getNominaVacaciones().remove(periodoVacacional.get());
+			nomina.getVacaciones().remove(periodoVacacional.get().getVacaciones());
+		} else if(PercepcionBL.CVE_PRIMA_VACACIONES_REPORTADAS.equalsIgnoreCase(percepcion.getClave())) {
+			periodoVacacional = nomina.getNominaVacaciones().stream().filter(item -> "R".equalsIgnoreCase(item.getTipoPrima() )).findFirst();
+			nomina.getNominaVacaciones().remove(periodoVacacional.get());
+			nomina.getVacaciones().remove(periodoVacacional.get().getVacaciones());
 		}
+		
+		boolean respuesta = nomina.getPercepciones().remove(percepcion);
 		
 		if(respuesta == false)
 			throw new SGPException("Ocurrió un problema para eliminar la percepción.");

--- a/src/main/webapp/protected/nomina/semanal/nomina-s-empleado-percepciones.xhtml
+++ b/src/main/webapp/protected/nomina/semanal/nomina-s-empleado-percepciones.xhtml
@@ -40,7 +40,7 @@
 								</p:inputNumber>
 							</p:column>
 							<p:column width="2rem">
-								<p:commandButton icon="pi pi-times" action="#{nominaS.eliminarPercepcion(percepcion)}" styleClass="ui-button-outlined ui-button-danger">
+								<p:commandButton icon="pi pi-times" actionListener="#{nominaS.eliminarPercepcion(percepcion)}" styleClass="ui-button-outlined ui-button-danger" onstart="PF('statusInfoDialog').show();" oncomplete="PF('statusInfoDialog').hide();">
 									<p:confirm header="Eliminar percepción" message="¿Está seguro que desea ELIMINAR la percepción #{percepcion.tipoPercepcion.clave} - #{percepcion.nombre}?" icon="pi pi-exclamation-triangle" />
 								</p:commandButton>
 							</p:column>

--- a/src/main/webapp/protected/nomina/semanal/nomina-s-empleado-vacaciones.xhtml
+++ b/src/main/webapp/protected/nomina/semanal/nomina-s-empleado-vacaciones.xhtml
@@ -5,7 +5,12 @@
                 xmlns:f="http://java.sun.com/jsf/core"
                 xmlns:jsf="http://xmlns.jcp.org/jsf">
 
-					<p:tab title="Prima Vacacional">
+					<p:tab>
+						<f:facet name="title">
+							<span>Prima Vacacional</span>
+							<p:badge severity="warning" value="#{nominaS.nomina.nominaVacaciones.size()}" visible="#{not empty nominaS.nomina.nominaVacaciones}" size="2">
+							</p:badge>
+						</f:facet>
 						<div class="ui-fluid formgrid grid">
 							<div class="field col-12 md:col-3">
 								<p:commandButton value="En tiempo" icon="pi pi-plus" process="@this" actionListener="#{nominaS.agregaPeriodoVacacional('T')}" onstart="PF('statusInfoDialog').show();" oncomplete="PF('statusInfoDialog').hide();">


### PR DESCRIPTION
En la nómina semanal, al eliminar una percepción en el pre-cálculo, se verifica si la percepción es "Prima vacacional (en tiempo o reportada)".

Si la percepción es eliminada, siendo una prima vacacional, se desvincula del objeto "nomina", para permitir que la percepción (Prima vacacional) se pueda agregar al un pago semanal posterior.